### PR TITLE
feat: add kill-tracker module with points, streaks, and leaderboards

### DIFF
--- a/modules/kill-tracker/config.json
+++ b/modules/kill-tracker/config.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "pvpKillPoints": {
+      "type": "number",
+      "default": 10,
+      "minimum": 0,
+      "description": "Points awarded for killing another player"
+    },
+    "mobKillPoints": {
+      "type": "number",
+      "default": 1,
+      "minimum": 0,
+      "description": "Points awarded for killing a mob or entity"
+    },
+    "deathPenalty": {
+      "type": "number",
+      "default": 5,
+      "minimum": 0,
+      "description": "Points deducted on death (floored at 0)"
+    },
+    "streakBonusInterval": {
+      "type": "number",
+      "default": 5,
+      "minimum": 1,
+      "description": "Every N kills awards bonus points (see streakBonusPoints)"
+    },
+    "streakBonusPoints": {
+      "type": "number",
+      "default": 25,
+      "minimum": 0,
+      "description": "Bonus points awarded at each streak milestone"
+    },
+    "streakBroadcast": {
+      "type": "boolean",
+      "default": true,
+      "description": "Broadcast streak milestones to the server"
+    },
+    "streakResetOnDeath": {
+      "type": "boolean",
+      "default": true,
+      "description": "Reset current streak on death"
+    },
+    "awardCurrency": {
+      "type": "boolean",
+      "default": false,
+      "description": "Also grant Takaro currency equal to points earned"
+    },
+    "leaderboardPageSize": {
+      "type": "number",
+      "default": 10,
+      "minimum": 1,
+      "maximum": 25,
+      "description": "Number of players per leaderboard page"
+    },
+    "killBroadcast": {
+      "type": "boolean",
+      "default": false,
+      "description": "Broadcast PvP kills to the server (mob kills are not broadcast)"
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/modules/kill-tracker/module.json
+++ b/modules/kill-tracker/module.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-kill-tracker",
+  "description": "Kill/Death Tracker — tracks player kills, deaths, and points with streaks, leaderboards, and seasonal resets.",
+  "version": "latest",
+  "supportedGames": ["all"]
+}

--- a/modules/kill-tracker/permissions.json
+++ b/modules/kill-tracker/permissions.json
@@ -1,0 +1,20 @@
+[
+  {
+    "permission": "KILL_TRACKER_VIEW_STATS",
+    "friendlyName": "View Kill Stats",
+    "description": "Allows a player to view kill stats and leaderboard",
+    "canHaveCount": false
+  },
+  {
+    "permission": "KILL_TRACKER_RESET",
+    "friendlyName": "Reset Kill Stats",
+    "description": "Allows an admin to reset kill stats for a player or all players",
+    "canHaveCount": false
+  },
+  {
+    "permission": "KILL_TRACKER_MULTIPLIER",
+    "friendlyName": "Point Multiplier",
+    "description": "Count = point multiplier for this player (e.g. count=2 means 2x points)",
+    "canHaveCount": true
+  }
+]

--- a/modules/kill-tracker/src/commands/leaderboard/command.json
+++ b/modules/kill-tracker/src/commands/leaderboard/command.json
@@ -1,0 +1,14 @@
+{
+  "trigger": "top",
+  "description": "View the kill points leaderboard",
+  "helpText": "View the top players ranked by points. Use /top [page] to browse pages.",
+  "arguments": [
+    {
+      "name": "page",
+      "type": "number",
+      "helpText": "Page number (default: 1)",
+      "position": 0,
+      "defaultValue": "1"
+    }
+  ]
+}

--- a/modules/kill-tracker/src/commands/leaderboard/index.js
+++ b/modules/kill-tracker/src/commands/leaderboard/index.js
@@ -1,0 +1,77 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getAllPlayerStats,
+  getSeasonInfo,
+  formatKD,
+  sortByRank,
+} from './tracker-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+  const config = mod.userConfig;
+  const moduleId = mod.moduleId;
+
+  if (!checkPermission(pog, 'KILL_TRACKER_VIEW_STATS')) {
+    throw new TakaroUserError('You do not have permission to view the leaderboard.');
+  }
+
+  const pageSize = config.leaderboardPageSize || 10;
+  const page = Math.floor(Math.max(1, args.page || 1));
+
+  const [allStats, season] = await Promise.all([
+    getAllPlayerStats(gameServerId, moduleId),
+    getSeasonInfo(gameServerId, moduleId),
+  ]);
+
+  if (allStats.length === 0) {
+    console.log(`leaderboard: no stats recorded yet, season=${season.number}`);
+    await pog.pm(`No stats recorded yet in Season ${season.number}. Go get some kills!`);
+    return;
+  }
+
+  const sorted = sortByRank(allStats);
+
+  const totalPages = Math.ceil(sorted.length / pageSize);
+  if (page > totalPages) {
+    throw new TakaroUserError(`Page ${page} does not exist. There ${totalPages === 1 ? 'is' : 'are'} only ${totalPages} ${totalPages === 1 ? 'page' : 'pages'}.`);
+  }
+
+  const startIndex = (page - 1) * pageSize;
+  const pageEntries = sorted.slice(startIndex, startIndex + pageSize);
+
+  // Resolve player names for this page in parallel
+  const playerNames = await Promise.all(
+    pageEntries.map(async (entry) => {
+      try {
+        const res = await takaro.player.playerControllerGetOne(entry.playerId);
+        return res.data.data.name || entry.playerId;
+      } catch (err) {
+        console.error(`leaderboard: failed to resolve name for player ${entry.playerId}: ${err}`);
+        return entry.playerId;
+      }
+    }),
+  );
+
+  const pagePoints = pageEntries.reduce((sum, e) => sum + e.stats.points, 0);
+  console.log(`leaderboard: page=${page}/${totalPages}, players=${pageEntries.length}, season=${season.number}, pagePoints=${pagePoints}`);
+
+  const lines = [`=== Top Players (Season ${season.number}) — Page ${page}/${totalPages} ===`];
+  for (let i = 0; i < pageEntries.length; i++) {
+    const entry = pageEntries[i];
+    const rank = startIndex + i + 1;
+    const name = playerNames[i];
+    const kd = formatKD(entry.stats.kills, entry.stats.deaths);
+    lines.push(`#${rank} ${name} | ${entry.stats.points} pts | K/D: ${kd}`);
+  }
+
+  if (page < totalPages) {
+    // Note: '/top' is hardcoded here because modules cannot access the server's configured command
+    // prefix at runtime. The standard prefix '/' is used as a fallback. Admins using a custom
+    // prefix will need to substitute accordingly.
+    lines.push(`Use /top ${page + 1} to see the next page.`);
+  }
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/kill-tracker/src/commands/resetstats/command.json
+++ b/modules/kill-tracker/src/commands/resetstats/command.json
@@ -1,0 +1,14 @@
+{
+  "trigger": "resetstats",
+  "description": "Reset kill stats (admin only)",
+  "helpText": "Admin command. Use /resetstats all to reset ALL stats and start a new season. Use /resetstats <player> to reset only that player's stats.",
+  "arguments": [
+    {
+      "name": "player",
+      "type": "string",
+      "helpText": "Player name to reset, or 'all' to reset all stats and start a new season.",
+      "position": 0,
+      "defaultValue": "?"
+    }
+  ]
+}

--- a/modules/kill-tracker/src/commands/resetstats/index.js
+++ b/modules/kill-tracker/src/commands/resetstats/index.js
@@ -1,0 +1,77 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  deleteAllPlayerStats,
+  deletePlayerStats,
+  getSeasonInfo,
+  setSeasonInfo,
+} from './tracker-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  if (!checkPermission(pog, 'KILL_TRACKER_RESET')) {
+    throw new TakaroUserError('You do not have permission to reset kill stats.');
+  }
+
+  const targetName = args.player && args.player.trim();
+
+  // Require explicit argument: "?" is the sentinel default — show usage if omitted.
+  if (!targetName || targetName === '?') {
+    throw new TakaroUserError(
+      'Please specify a target. Use "/resetstats all" to reset all stats and start a new season, or "/resetstats <player>" to reset a specific player.',
+    );
+  }
+
+  if (targetName === 'all') {
+    // Full reset: delete all stats and increment season
+    await deleteAllPlayerStats(gameServerId, moduleId);
+
+    const season = await getSeasonInfo(gameServerId, moduleId);
+    const newSeasonNumber = season.number + 1;
+    await setSeasonInfo(gameServerId, moduleId, {
+      number: newSeasonNumber,
+      startedAt: new Date().toISOString(),
+    });
+
+    console.log(`resetstats: full reset by ${player.name}, new season=${newSeasonNumber}`);
+
+    await pog.pm(`Season ${newSeasonNumber} has begun! All kill stats have been reset.`);
+
+    try {
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `Season ${newSeasonNumber} has begun! All kill stats have been reset.`,
+        opts: {},
+      });
+    } catch (err) {
+      console.error(`resetstats: failed to broadcast season start: ${err}`);
+    }
+  } else {
+    // Per-player reset: find player by name, delete their stats
+    const playerSearch = await takaro.player.playerControllerSearch({
+      search: { name: [targetName] },
+    });
+
+    const found = playerSearch.data.data.find(
+      (p) => p.name.toLowerCase() === targetName.toLowerCase(),
+    );
+
+    if (!found) {
+      throw new TakaroUserError(`Player "${targetName}" not found.`);
+    }
+
+    const season = await getSeasonInfo(gameServerId, moduleId);
+
+    const hadStats = await deletePlayerStats(gameServerId, moduleId, found.id);
+
+    console.log(`resetstats: reset stats for player=${found.name} (id=${found.id}) by ${player.name}, hadStats=${hadStats}`);
+
+    if (hadStats) {
+      await pog.pm(`Kill stats for "${found.name}" have been reset (Season ${season.number}).`);
+    } else {
+      await pog.pm(`"${found.name}" had no recorded stats this season.`);
+    }
+  }
+}
+
+await main();

--- a/modules/kill-tracker/src/commands/stats/command.json
+++ b/modules/kill-tracker/src/commands/stats/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "stats",
+  "description": "View your kill/death stats and rank",
+  "helpText": "View your personal kill stats, K/D ratio, points, streak, and current rank for the current season.",
+  "arguments": []
+}

--- a/modules/kill-tracker/src/commands/stats/index.js
+++ b/modules/kill-tracker/src/commands/stats/index.js
@@ -1,0 +1,54 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getPlayerStats,
+  getAllPlayerStats,
+  getSeasonInfo,
+  formatKD,
+  sortByRank,
+} from './tracker-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  if (!checkPermission(pog, 'KILL_TRACKER_VIEW_STATS')) {
+    throw new TakaroUserError('You do not have permission to view kill stats.');
+  }
+
+  // Known scaling limitation: getAllPlayerStats fetches all player records to compute rank.
+  // Acceptable for typical game server sizes (< a few thousand players).
+  const [stats, allStats, season] = await Promise.all([
+    getPlayerStats(gameServerId, moduleId, player.id),
+    getAllPlayerStats(gameServerId, moduleId),
+    getSeasonInfo(gameServerId, moduleId),
+  ]);
+
+  // Compute rank (1-based, sorted by points desc, then kills as tiebreaker)
+  const sorted = sortByRank(allStats);
+
+  const rankIndex = sorted.findIndex((entry) => entry.playerId === player.id);
+  // rankIndex === -1 means the player has no stored stats yet — show "Unranked"
+  const rankDisplay = rankIndex === -1 ? 'Unranked' : `#${rankIndex + 1}/${allStats.length}`;
+
+  const kd = formatKD(stats.kills, stats.deaths);
+
+  const isNewPlayer = stats.kills === 0 && stats.deaths === 0 && stats.points === 0;
+
+  const lines = [
+    `=== Kill Stats: ${player.name} — Season ${season.number} ===`,
+    `Points: ${stats.points} | Rank: ${rankDisplay}`,
+    `Kills: ${stats.kills} (PvP: ${stats.pvpKills} | Mob: ${stats.mobKills})`,
+    `Deaths: ${stats.deaths} | K/D: ${kd}`,
+    `Current Streak: ${stats.currentStreak} | Best Streak: ${stats.bestStreak}`,
+  ];
+
+  if (isNewPlayer) {
+    lines.push('Start killing to earn points and climb the leaderboard!');
+  }
+
+  console.log(`stats: player=${player.name}, points=${stats.points}, rank=${rankDisplay}, kills=${stats.kills}, deaths=${stats.deaths}`);
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/kill-tracker/src/functions/tracker-helpers.js
+++ b/modules/kill-tracker/src/functions/tracker-helpers.js
@@ -1,0 +1,210 @@
+import { takaro } from '@takaro/helpers';
+
+export const STATS_KEY = 'kt_stats';
+export const SEASON_KEY = 'kt_season';
+
+export const DEFAULT_STATS = {
+  kills: 0,
+  pvpKills: 0,
+  mobKills: 0,
+  deaths: 0,
+  points: 0,
+  currentStreak: 0,
+  bestStreak: 0,
+};
+
+async function findVariable(gameServerId, moduleId, key, playerId) {
+  const filters = {
+    key: [key],
+    gameServerId: [gameServerId],
+    moduleId: [moduleId],
+  };
+  if (playerId) {
+    filters.playerId = [playerId];
+  }
+
+  const res = await takaro.variable.variableControllerSearch({ filters });
+  return res.data.data.length > 0 ? res.data.data[0] : null;
+}
+
+async function writeVariable(gameServerId, moduleId, key, playerId, value) {
+  const existing = await findVariable(gameServerId, moduleId, key, playerId);
+  const serialized = JSON.stringify(value);
+  if (existing) {
+    await takaro.variable.variableControllerUpdate(existing.id, { value: serialized });
+  } else {
+    const createData = {
+      key,
+      value: serialized,
+      gameServerId,
+      moduleId,
+    };
+    if (playerId) {
+      createData.playerId = playerId;
+    }
+    await takaro.variable.variableControllerCreate(createData);
+  }
+}
+
+/**
+ * Get stats for a specific player. Returns DEFAULT_STATS if not found.
+ * Merges parsed value with DEFAULT_STATS so partial/old records never cause NaN.
+ *
+ * Note: read-modify-write — concurrent events for the same player may lose an update
+ * (no atomic ops in the variable API). Accepted limitation; rare in practice.
+ */
+export async function getPlayerStats(gameServerId, moduleId, playerId) {
+  const variable = await findVariable(gameServerId, moduleId, STATS_KEY, playerId);
+  if (!variable) return { ...DEFAULT_STATS };
+  try {
+    return { ...DEFAULT_STATS, ...JSON.parse(variable.value) };
+  } catch (err) {
+    console.error(`tracker-helpers: getPlayerStats failed to parse stats for player ${playerId}. Returning defaults. Error: ${err}`);
+    return { ...DEFAULT_STATS };
+  }
+}
+
+export async function setPlayerStats(gameServerId, moduleId, playerId, stats) {
+  await writeVariable(gameServerId, moduleId, STATS_KEY, playerId, stats);
+}
+
+export async function getAllPlayerStats(gameServerId, moduleId) {
+  const results = [];
+  const limit = 100;
+  let page = 0;
+
+  while (true) {
+    const res = await takaro.variable.variableControllerSearch({
+      filters: {
+        key: [STATS_KEY],
+        gameServerId: [gameServerId],
+        moduleId: [moduleId],
+      },
+      limit,
+      page,
+    });
+
+    const records = res.data.data;
+    for (const record of records) {
+      if (!record.playerId) continue;
+      try {
+        const stats = { ...DEFAULT_STATS, ...JSON.parse(record.value) };
+        results.push({ playerId: record.playerId, stats });
+      } catch (err) {
+        console.error(`tracker-helpers: getAllPlayerStats failed to parse stats for player ${record.playerId}. Skipping. Error: ${err}`);
+      }
+    }
+
+    if (records.length < limit) break;
+    page++;
+  }
+
+  return results;
+}
+
+export async function deleteAllPlayerStats(gameServerId, moduleId) {
+  const limit = 100;
+  let iterations = 0;
+
+  while (true) {
+    if (iterations > 100) {
+      console.error('deleteAllPlayerStats: safety limit reached, some records may remain');
+      break;
+    }
+
+    const res = await takaro.variable.variableControllerSearch({
+      filters: {
+        key: [STATS_KEY],
+        gameServerId: [gameServerId],
+        moduleId: [moduleId],
+      },
+      limit,
+      page: 0,
+    });
+
+    const records = res.data.data;
+    if (records.length === 0) break;
+
+    // Delete all records in parallel; use allSettled so one failure doesn't abort the rest
+    const results = await Promise.allSettled(records.map((record) => takaro.variable.variableControllerDelete(record.id)));
+    for (const result of results) {
+      if (result.status === 'rejected') {
+        console.error(`tracker-helpers: deleteAllPlayerStats failed to delete a variable: ${result.reason}`);
+      }
+    }
+
+    if (records.length < limit) break;
+    iterations++;
+  }
+}
+
+// Returns true if a record was found and deleted, false if none existed.
+export async function deletePlayerStats(gameServerId, moduleId, playerId) {
+  const variable = await findVariable(gameServerId, moduleId, STATS_KEY, playerId);
+  if (variable) {
+    await takaro.variable.variableControllerDelete(variable.id);
+    return true;
+  }
+  return false;
+}
+
+export async function getSeasonInfo(gameServerId, moduleId) {
+  const defaultSeason = { number: 1, startedAt: new Date().toISOString() };
+  const variable = await findVariable(gameServerId, moduleId, SEASON_KEY, null);
+  if (!variable) {
+    return { ...defaultSeason };
+  }
+  try {
+    const season = JSON.parse(variable.value);
+    if (typeof season.number !== 'number' || isNaN(season.number)) {
+      console.error(`tracker-helpers: getSeasonInfo found invalid season number (${season.number}). Returning defaults.`);
+      return { ...defaultSeason };
+    }
+    return season;
+  } catch (err) {
+    console.error(`tracker-helpers: getSeasonInfo failed to parse season data. Returning defaults. Error: ${err}`);
+    return { ...defaultSeason };
+  }
+}
+
+export async function setSeasonInfo(gameServerId, moduleId, data) {
+  await writeVariable(gameServerId, moduleId, SEASON_KEY, null, data);
+}
+
+export function formatKD(kills, deaths) {
+  if (kills === 0 && deaths === 0) return 'N/A';
+  if (deaths === 0) return `${kills} (no deaths)`;
+  return (kills / deaths).toFixed(2);
+}
+
+export function sortByRank(allStats) {
+  return [...allStats].sort((a, b) => {
+    if (b.stats.points !== a.stats.points) return b.stats.points - a.stats.points;
+    return b.stats.kills - a.stats.kills;
+  });
+}
+
+export function recordKill(stats, killType, config, basePoints, multiplier) {
+  stats.kills += 1;
+  if (killType === 'pvp') {
+    stats.pvpKills += 1;
+  } else {
+    stats.mobKills += 1;
+  }
+  stats.currentStreak += 1;
+  if (stats.currentStreak > stats.bestStreak) {
+    stats.bestStreak = stats.currentStreak;
+  }
+
+  const pointsEarned = basePoints * multiplier;
+  stats.points += pointsEarned;
+
+  let bonusAwarded = 0;
+  const streakInterval = config.streakBonusInterval;
+  if (streakInterval > 0 && stats.currentStreak % streakInterval === 0) {
+    bonusAwarded = config.streakBonusPoints;
+    stats.points += bonusAwarded;
+  }
+
+  return { pointsEarned, bonusAwarded };
+}

--- a/modules/kill-tracker/src/hooks/on-death/hook.json
+++ b/modules/kill-tracker/src/hooks/on-death/hook.json
@@ -1,0 +1,4 @@
+{
+  "eventType": "player-death",
+  "description": "Track player deaths, apply death penalty, and attribute PvP kills to the attacker"
+}

--- a/modules/kill-tracker/src/hooks/on-death/index.js
+++ b/modules/kill-tracker/src/hooks/on-death/index.js
@@ -1,0 +1,101 @@
+import { data, takaro, checkPermission } from '@takaro/helpers';
+import {
+  getPlayerStats,
+  setPlayerStats,
+  recordKill,
+} from './tracker-helpers.js';
+
+async function main() {
+  const { gameServerId, eventData, player, module: mod } = data;
+  const config = mod.userConfig;
+  const moduleId = mod.moduleId;
+
+  // Process victim (the player who died); if this throws, attacker processing still runs below
+  try {
+    const victimStats = await getPlayerStats(gameServerId, moduleId, player.id);
+    victimStats.deaths += 1;
+    victimStats.points = Math.max(0, victimStats.points - config.deathPenalty);
+
+    if (config.streakResetOnDeath) {
+      victimStats.currentStreak = 0;
+    }
+
+    console.log(`on-death: victim=${player.name}, deaths=${victimStats.deaths}, points=${victimStats.points}, streak=${victimStats.currentStreak}`);
+    await setPlayerStats(gameServerId, moduleId, player.id, victimStats);
+  } catch (err) {
+    console.error(`on-death: failed to process victim stats for ${player.name}: ${err} — continuing to attacker processing`);
+  }
+
+  // Process attacker if there is one and they are not the victim (suicide check)
+  const attackerGameId = eventData && eventData.attacker && eventData.attacker.gameId;
+  if (!attackerGameId || attackerGameId === player.gameId) {
+    // No attacker, or self-kill — done
+    return;
+  }
+
+  // Look up attacker by gameId on this game server
+  let attackerPog;
+  try {
+    const searchResult = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: {
+        gameId: [attackerGameId],
+        gameServerId: [gameServerId],
+      },
+    });
+    attackerPog = searchResult.data.data.length > 0 ? searchResult.data.data[0] : null;
+  } catch (err) {
+    console.error(`on-death: failed to look up attacker with gameId=${attackerGameId}: ${err}`);
+    return;
+  }
+
+  if (!attackerPog) {
+    console.log(`on-death: attacker gameId=${attackerGameId} not found in Takaro — skipping PvP attribution`);
+    return;
+  }
+
+  // Determine attacker multiplier
+  const multiplierPerm = checkPermission(attackerPog, 'KILL_TRACKER_MULTIPLIER');
+  const multiplier = (multiplierPerm && multiplierPerm.count > 0) ? multiplierPerm.count : 1;
+
+  const attackerStats = await getPlayerStats(gameServerId, moduleId, attackerPog.playerId);
+  const { pointsEarned, bonusAwarded } = recordKill(attackerStats, 'pvp', config, config.pvpKillPoints, multiplier);
+
+  console.log(`on-death: attacker=${attackerPog.player?.name || attackerGameId}, pvpKills=${attackerStats.pvpKills}, streak=${attackerStats.currentStreak}, pointsEarned=${pointsEarned}, bonus=${bonusAwarded}, totalPoints=${attackerStats.points}`);
+
+  // Save stats BEFORE any broadcasts so data is persisted even if broadcast fails
+  await setPlayerStats(gameServerId, moduleId, attackerPog.playerId, attackerStats);
+
+  if (bonusAwarded > 0 && config.streakBroadcast) {
+    try {
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `${attackerPog.player?.name || attackerGameId} is on a ${attackerStats.currentStreak}-PvP-kill streak! (+${bonusAwarded} bonus points)`,
+        opts: {},
+      });
+    } catch (err) {
+      console.error(`on-death: failed to broadcast streak for ${attackerPog.player?.name || attackerGameId}: ${err}`);
+    }
+  }
+
+  if (config.killBroadcast) {
+    try {
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `${attackerPog.player?.name || attackerGameId} eliminated ${player.name} in PvP! (+${pointsEarned} points)`,
+        opts: {},
+      });
+    } catch (err) {
+      console.error(`on-death: failed to broadcast PvP kill for ${attackerPog.player?.name || attackerGameId}: ${err}`);
+    }
+  }
+
+  if (config.awardCurrency && pointsEarned + bonusAwarded > 0) {
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, attackerPog.playerId, {
+        currency: pointsEarned + bonusAwarded,
+      });
+    } catch (err) {
+      console.error(`on-death: failed to award currency to attacker ${attackerPog.player?.name || attackerGameId}: ${err}`);
+    }
+  }
+}
+
+await main();

--- a/modules/kill-tracker/src/hooks/on-kill/hook.json
+++ b/modules/kill-tracker/src/hooks/on-kill/hook.json
@@ -1,0 +1,4 @@
+{
+  "eventType": "entity-killed",
+  "description": "Track mob kills and award points when a player kills an entity"
+}

--- a/modules/kill-tracker/src/hooks/on-kill/index.js
+++ b/modules/kill-tracker/src/hooks/on-kill/index.js
@@ -1,0 +1,63 @@
+import { data, takaro, checkPermission } from '@takaro/helpers';
+import {
+  getPlayerStats,
+  setPlayerStats,
+  recordKill,
+} from './tracker-helpers.js';
+
+async function main() {
+  const { gameServerId, eventData, player, module: mod } = data;
+  const config = mod.userConfig;
+  const moduleId = mod.moduleId;
+
+  // PvP kills (victim has gameId) are handled by on-death hook; skip here.
+  if (eventData && eventData.victim && eventData.victim.gameId) {
+    console.log(`on-kill: skipping PvP kill, victim is a player (gameId=${eventData.victim.gameId})`);
+    return;
+  }
+
+  // Fetch the player-on-gameserver record to check permissions
+  let pog;
+  try {
+    pog = (await takaro.playerOnGameserver.playerOnGameServerControllerGetOne(gameServerId, player.id)).data.data;
+  } catch (err) {
+    console.error(`on-kill: failed to fetch pog for player ${player.name}: ${err} — defaulting multiplier to 1`);
+    pog = null;
+  }
+
+  // Determine multiplier from KILL_TRACKER_MULTIPLIER permission
+  const multiplierPerm = pog ? checkPermission(pog, 'KILL_TRACKER_MULTIPLIER') : null;
+  const multiplier = (multiplierPerm && multiplierPerm.count > 0) ? multiplierPerm.count : 1;
+
+  const stats = await getPlayerStats(gameServerId, moduleId, player.id);
+
+  const { pointsEarned, bonusAwarded } = recordKill(stats, 'mob', config, config.mobKillPoints, multiplier);
+
+  console.log(`on-kill: mob kill player=${player.name}, mobKills=${stats.mobKills}, streak=${stats.currentStreak}, pointsEarned=${pointsEarned}, bonus=${bonusAwarded}, totalPoints=${stats.points}`);
+
+  // Save stats BEFORE any broadcasts so data is persisted even if broadcast fails
+  await setPlayerStats(gameServerId, moduleId, player.id, stats);
+
+  if (bonusAwarded > 0 && config.streakBroadcast) {
+    try {
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `${player.name} is on a ${stats.currentStreak}-mob-kill streak! (+${bonusAwarded} bonus points)`,
+        opts: {},
+      });
+    } catch (err) {
+      console.error(`on-kill: failed to broadcast mob streak for ${player.name}: ${err}`);
+    }
+  }
+
+  if (config.awardCurrency && pointsEarned + bonusAwarded > 0) {
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, player.id, {
+        currency: pointsEarned + bonusAwarded,
+      });
+    } catch (err) {
+      console.error(`on-kill: failed to award currency to player ${player.name}: ${err}`);
+    }
+  }
+}
+
+await main();

--- a/modules/kill-tracker/test/leaderboard.test.ts
+++ b/modules/kill-tracker/test/leaderboard.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// player[0] has KILL_TRACKER_VIEW_STATS permission
+// player[1] does NOT
+
+describe('kill-tracker: /top leaderboard command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let viewRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        mobKillPoints: 5,
+        pvpKillPoints: 10,
+        deathPenalty: 3,
+        streakBonusInterval: 10,
+        streakBonusPoints: 50,
+        streakBroadcast: false,
+        streakResetOnDeath: true,
+        awardCurrency: false,
+        leaderboardPageSize: 5,
+        killBroadcast: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    viewRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['KILL_TRACKER_VIEW_STATS'],
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, viewRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show empty leaderboard message when no stats recorded', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}top`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected command to succeed even with empty leaderboard');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('leaderboard:')),
+      `Expected leaderboard log, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show ranked players after kills', async () => {
+    const player = ctx.players[0]!;
+
+    // Trigger 2 mob kills for player[0]
+    for (let i = 0; i < 2; i++) {
+      const before = new Date();
+      await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+      await waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+        gameserverId: ctx.gameServer.id,
+        after: before,
+        timeout: 30000,
+      });
+    }
+
+    // Now check leaderboard
+    const topBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}top`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: topBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected leaderboard command to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('players=1') || msg.includes('page=')),
+      `Expected leaderboard page log, got: ${JSON.stringify(logMessages)}`,
+    );
+    // 2 mob kills at mobKillPoints=5 each = 10 total points; verify points appear in log
+    assert.ok(
+      logMessages.some((msg) => msg.includes('pagePoints=10')),
+      `Expected log to mention pagePoints=10, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should deny leaderboard to player without KILL_TRACKER_VIEW_STATS permission', async () => {
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}top`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail without permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should fail with invalid page number', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}top 999`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail for out-of-range page');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('does not exist') || msg.includes('page')),
+      `Expected page error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/kill-tracker/test/on-kill.test.ts
+++ b/modules/kill-tracker/test/on-kill.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// Tests trigger entity-killed events using the mock server console command:
+//   triggerKill <playerGameId>
+// This fires an entity-killed event for the specified player (mob kill — no player victim).
+//
+// NOTE: The on-death hook (player-death → death penalty + PvP attribution) is NOT tested
+// here because the mock server does not implement a triggerDeath console command. The
+// mock server's executeConsoleCommand only supports: version, connectAll, disconnectAll,
+// scenario, say, ban, unban, triggerKill, setPlayerPing.
+// Death hook behaviour is verified manually via in-game testing with real bots.
+// See: test/helpers/mock-server.ts and @takaro/mock-gameserver source for available commands.
+
+describe('kill-tracker: on-kill hook (mob kill tracking)', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let viewRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        mobKillPoints: 5,
+        pvpKillPoints: 10,
+        deathPenalty: 3,
+        streakBonusInterval: 3,
+        streakBonusPoints: 15,
+        streakBroadcast: false,
+        streakResetOnDeath: true,
+        awardCurrency: false,
+        leaderboardPageSize: 10,
+        killBroadcast: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Grant player[0] KILL_TRACKER_VIEW_STATS so we can verify state with /stats
+    viewRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['KILL_TRACKER_VIEW_STATS'],
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, viewRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should track a mob kill and award points', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    // triggerKill <gameId> fires entity-killed event for that player (no player victim = mob kill)
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a hook-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected hook to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('on-kill: mob kill')),
+      `Expected log to contain "on-kill: mob kill", got: ${JSON.stringify(logMessages)}`,
+    );
+    assert.ok(
+      logMessages.some((msg) => msg.includes('mobKills=1')),
+      `Expected log to show mobKills=1, got: ${JSON.stringify(logMessages)}`,
+    );
+    // mobKillPoints=5 in config, verify specific point value
+    assert.ok(
+      logMessages.some((msg) => msg.includes('pointsEarned=5')),
+      `Expected log to show pointsEarned=5 (mobKillPoints=5 * multiplier=1), got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify persisted state with /stats command
+    const statsBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}stats`,
+      playerId: player.playerId,
+    });
+    const statsEvent = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: statsBefore,
+      timeout: 30000,
+    });
+    assert.ok(statsEvent, 'Expected stats command-executed event');
+    const statsMeta = statsEvent.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(statsMeta?.result?.success, true, 'Expected stats command to succeed');
+    const statsLogs = (statsMeta?.result?.logs ?? []).map((l) => l.msg);
+    // Verify kills=1 and points=5 are persisted
+    assert.ok(
+      statsLogs.some((msg) => msg.includes('kills=1') && msg.includes('points=5')),
+      `Expected stats to show kills=1 and points=5, got: ${JSON.stringify(statsLogs)}`,
+    );
+  });
+
+  it('should track streak and award bonus at milestone', async () => {
+    // Depends on previous test: player[0] already has 1 mob kill (streak=1).
+    // The streak bonus fires every 3 kills (streakBonusInterval=3).
+    // So 2 more kills bring streak to 3, triggering the bonus.
+    const player = ctx.players[0]!;
+
+    // Trigger kill #2 (streak=2)
+    const before2 = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before2,
+      timeout: 30000,
+    });
+
+    // Trigger kill #3 (streak=3 → milestone fires bonus=15)
+    const before3 = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+    const milestoneEvent = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before3,
+      timeout: 30000,
+    });
+
+    assert.ok(milestoneEvent, 'Expected a hook-executed event for streak milestone');
+    const meta = milestoneEvent.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected hook to succeed on streak milestone');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('on-kill: mob kill')),
+      `Expected mob kill log, got: ${JSON.stringify(logMessages)}`,
+    );
+    // At streak=3 (milestone interval=3), bonus=15 should be awarded
+    assert.ok(
+      logMessages.some((msg) => msg.includes('bonus=15') && msg.includes('streak=3')),
+      `Expected streak bonus log with bonus=15 and streak=3, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should apply KILL_TRACKER_MULTIPLIER (count=2) to double points', async () => {
+    // Depends on previous tests: player[1] has no kills yet. Grant them a 2x multiplier.
+    const player = ctx.players[1]!;
+
+    const multiplierRoleId = await assignPermissions(
+      client,
+      player.playerId,
+      ctx.gameServer.id,
+      [{ code: 'KILL_TRACKER_MULTIPLIER', count: 2 }],
+    );
+
+    try {
+      const before = new Date();
+      await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+      const event = await waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+        gameserverId: ctx.gameServer.id,
+        after: before,
+        timeout: 30000,
+      });
+
+      assert.ok(event, 'Expected a hook-executed event with multiplier');
+      const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+      assert.equal(meta?.result?.success, true, 'Expected hook to succeed with multiplier');
+
+      const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+      // mobKillPoints=5, multiplier=2 → pointsEarned=10
+      assert.ok(
+        logMessages.some((msg) => msg.includes('pointsEarned=10')),
+        `Expected pointsEarned=10 (5 * 2x multiplier), got: ${JSON.stringify(logMessages)}`,
+      );
+    } finally {
+      await cleanupRole(client, multiplierRoleId);
+    }
+  });
+
+  it('should execute hook for additional player (third player mob kill)', async () => {
+    // Verify the hook fires correctly for a third player with no prior kills.
+    // awardCurrency is false in this test suite; currency awarding is verified in-game.
+    const player = ctx.players[2]!;
+    const before = new Date();
+
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a hook-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected hook to succeed');
+  });
+});

--- a/modules/kill-tracker/test/resetstats.test.ts
+++ b/modules/kill-tracker/test/resetstats.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// player[0] has KILL_TRACKER_RESET permission
+// player[1] has KILL_TRACKER_VIEW_STATS permission (for verification via /top and /stats)
+// player[2] has no permissions
+
+describe('kill-tracker: /resetstats command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let resetRoleId: string;
+  let viewRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Wait until all 3 players are online
+    const maxWait = 30000;
+    const pollInterval = 2000;
+    const start = Date.now();
+    while (ctx.players.length < 3 && Date.now() - start < maxWait) {
+      await new Promise((resolve) => setTimeout(resolve, pollInterval));
+      const res = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+      });
+      if (res.data.data.length >= 3) {
+        ctx.players = res.data.data;
+        break;
+      }
+    }
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        mobKillPoints: 5,
+        pvpKillPoints: 10,
+        deathPenalty: 3,
+        streakBonusInterval: 10,
+        streakBonusPoints: 50,
+        streakBroadcast: false,
+        streakResetOnDeath: true,
+        awardCurrency: false,
+        leaderboardPageSize: 10,
+        killBroadcast: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    resetRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['KILL_TRACKER_RESET'],
+    );
+
+    viewRoleId = await assignPermissions(
+      client,
+      ctx.players[1].playerId,
+      ctx.gameServer.id,
+      ['KILL_TRACKER_VIEW_STATS'],
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, resetRoleId);
+    await cleanupRole(client, viewRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should deny resetstats to player without KILL_TRACKER_RESET permission', async () => {
+    const player = ctx.players[2]!;
+    const before = new Date();
+
+    // Permission check fires before argument validation, so no-arg still tests auth
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}resetstats`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail without reset permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should fail without an explicit argument to prevent accidental reset', async () => {
+    // Requires KILL_TRACKER_RESET permission (player[0]). Without an arg, the command
+    // should throw a TakaroUserError asking for an explicit target.
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}resetstats`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail with no argument (destructive guard)');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('specify a target') || msg.includes('resetstats all')),
+      `Expected usage error message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should reset all stats and start a new season when /resetstats all is used', async () => {
+    // First generate some kills so we have stats to reset
+    const player0 = ctx.players[0]!;
+    const killBefore = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player0.gameId}`);
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: killBefore,
+      timeout: 30000,
+    });
+
+    // Reset all stats with explicit 'all' argument
+    const resetBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}resetstats all`,
+      playerId: player0.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: resetBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected full reset to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('resetstats: full reset') || msg.includes('new season=')),
+      `Expected full reset log, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should verify stats are cleared after full reset', async () => {
+    // Depends on previous test: full reset was run, so leaderboard should be empty.
+    // Use player[1] who has VIEW_STATS to check leaderboard is empty.
+    const player1 = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}top`,
+      playerId: player1.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected leaderboard to succeed after reset');
+
+    // After a full reset, leaderboard should show "No stats" message
+    // (The command sends a PM but logs via console.log in the leaderboard command)
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('leaderboard:')),
+      `Expected leaderboard log after reset, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should fail with error when player name not found', async () => {
+    const player0 = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}resetstats nonexistentplayername123`,
+      playerId: player0.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail for non-existent player');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('not found') || msg.includes('nonexistentplayername123')),
+      `Expected "not found" error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should reset only a specific player stats when given a player name', async () => {
+    // Depends on previous test: after full reset, all stats are at 0.
+    // Give player[0] a kill, then reset only player[0]'s stats.
+    // player[1] should retain their stats (though they have no kills in this test).
+    const player0 = ctx.players[0]!;
+    const player1 = ctx.players[1]!;
+
+    // Give player[0] some kills
+    const kill1Before = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player0.gameId}`);
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: kill1Before,
+      timeout: 30000,
+    });
+
+    // Give player[1] some kills too so we can verify they survive the per-player reset
+    const kill2Before = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player1.gameId}`);
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: kill2Before,
+      timeout: 30000,
+    });
+
+    // Resolve player[0]'s Takaro display name for the resetstats command
+    const player0Info = await client.player.playerControllerGetOne(player0.playerId);
+    const player0Name = player0Info.data.data.name;
+
+    // Reset only player[0]'s stats
+    const resetBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}resetstats ${player0Name}`,
+      playerId: player0.playerId,
+    });
+
+    const resetEvent = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: resetBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(resetEvent, 'Expected a command-executed event');
+    const resetMeta = resetEvent.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(resetMeta?.result?.success, true, 'Expected per-player reset to succeed');
+
+    const resetLogs = (resetMeta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      resetLogs.some((msg) => msg.includes('reset stats for player=') || msg.includes(player0Name)),
+      `Expected per-player reset log mentioning player name, got: ${JSON.stringify(resetLogs)}`,
+    );
+
+    // Verify player[1] still has stats (their kill should be intact)
+    // player[1] has KILL_TRACKER_VIEW_STATS so can run /stats
+    const statsBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}stats`,
+      playerId: player1.playerId,
+    });
+
+    const statsEvent = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: statsBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(statsEvent, 'Expected stats command-executed event for player[1]');
+    const statsMeta = statsEvent.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(statsMeta?.result?.success, true, 'Expected stats command to succeed for player[1]');
+
+    const statsLogs = (statsMeta?.result?.logs ?? []).map((l) => l.msg);
+    // player[1] should have kills=1 from their kill above (not reset)
+    assert.ok(
+      statsLogs.some((msg) => msg.includes('kills=1')),
+      `Expected player[1] to still have kills=1 after per-player reset of player[0], got: ${JSON.stringify(statsLogs)}`,
+    );
+  });
+});

--- a/modules/kill-tracker/test/stats.test.ts
+++ b/modules/kill-tracker/test/stats.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// player[0] has KILL_TRACKER_VIEW_STATS permission
+// player[1] does NOT have any permissions
+
+describe('kill-tracker: /stats command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let viewRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        mobKillPoints: 5,
+        pvpKillPoints: 10,
+        deathPenalty: 3,
+        streakBonusInterval: 5,
+        streakBonusPoints: 25,
+        streakBroadcast: false,
+        streakResetOnDeath: true,
+        awardCurrency: false,
+        leaderboardPageSize: 10,
+        killBroadcast: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    viewRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['KILL_TRACKER_VIEW_STATS'],
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, viewRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show default stats for a new player with no kills', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}stats`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected command to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('stats: player=')),
+      `Expected stats log, got: ${JSON.stringify(logMessages)}`,
+    );
+    assert.ok(
+      logMessages.some((msg) => msg.includes('kills=0') && msg.includes('deaths=0')),
+      `Expected zero kills and deaths, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show updated stats after a kill', async () => {
+    // Depends on previous test: player[0] may already have stats. This test triggers
+    // exactly one more kill and verifies kills increments by checking kills=1.
+    // Note: stats.test.ts runs with a fresh module install in each before(), so
+    // player[0] starts from 0 kills in this describe block.
+    const player = ctx.players[0]!;
+
+    // Trigger a mob kill
+    const killBefore = new Date();
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: killBefore,
+      timeout: 30000,
+    });
+
+    // Now check stats
+    const statsBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}stats`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: statsBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected stats command to succeed after kill');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('kills=1')),
+      `Expected kills=1 in stats log, got: ${JSON.stringify(logMessages)}`,
+    );
+    // mobKillPoints=5 in config — verify exact point value persisted
+    assert.ok(
+      logMessages.some((msg) => msg.includes('points=5')),
+      `Expected points=5 (mobKillPoints=5 * 1 kill), got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should deny stats to player without KILL_TRACKER_VIEW_STATS permission', async () => {
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}stats`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail when player lacks permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/test/helpers/modules.ts
+++ b/test/helpers/modules.ts
@@ -173,26 +173,37 @@ export async function cleanupTestModules(client: Client): Promise<void> {
   }
 }
 
+export interface PermissionInput {
+  code: string;
+  count?: number;
+}
+
 /**
  * Create a role with specific module permissions and assign it to a player.
  * Returns the role ID for cleanup.
+ * Accepts either string[] (no count) or PermissionInput[] (with optional count).
  */
 export async function assignPermissions(
   client: Client,
   playerId: string,
   gameServerId: string,
-  permissionCodes: string[],
+  permissionCodes: string[] | PermissionInput[],
 ): Promise<string> {
   if (permissionCodes.length === 0) throw new Error('assignPermissions: permissionCodes must not be empty');
+
+  // Normalize to PermissionInput[] format
+  const normalized: PermissionInput[] = permissionCodes.map((p) =>
+    typeof p === 'string' ? { code: p } : p,
+  );
+
   const allPerms = await client.role.roleControllerGetPermissions();
-  const permInputs = allPerms.data.data
-    .filter((p) => permissionCodes.includes(p.permission))
-    .map((p) => ({ permissionId: p.id }));
-  if (permInputs.length !== permissionCodes.length) {
-    const found = allPerms.data.data.filter((p) => permissionCodes.includes(p.permission)).map((p) => p.permission);
-    const missing = permissionCodes.filter((c) => !found.includes(c));
-    throw new Error(`Permissions not found: ${missing.join(', ')}. Available: ${allPerms.data.data.map((p) => p.permission).join(', ')}`);
-  }
+  const permInputs = normalized.map((input) => {
+    const found = allPerms.data.data.find((p) => p.permission === input.code);
+    if (!found) throw new Error(`Permission '${input.code}' not found`);
+    const result: { permissionId: string; count?: number } = { permissionId: found.id };
+    if (input.count !== undefined) result.count = input.count;
+    return result;
+  });
   // Role name max length is 20 chars. Include randomness to avoid collisions when tests run in parallel.
   // Format: "tr-" (3) + 5 base-36 timestamp chars + 4 base-36 random chars = 12 chars total. Well under 20.
   const role = await client.role.roleControllerCreate({


### PR DESCRIPTION
## Summary

- Adds a kill/death tracker module that awards configurable points for PvP kills, mob kills, and applies death penalties
- Tracks kill streaks with milestone bonuses and server broadcasts
- Provides `/stats` (personal K/D/points/rank), `/top` (paginated leaderboard), and `/resetstats` (admin season resets)
- 3 permissions: VIEW_STATS, RESET, and MULTIPLIER (count-based for VIP point multipliers)
- 10 configurable settings (point values, streak intervals, broadcast toggles, currency integration)
- Extends `assignPermissions` test helper to support count-based permissions

Resolves gettakaro/community-modules-viewer#214

## Test plan

- [x] 17 automated integration tests across 4 suites (leaderboard, on-kill, resetstats, stats)
- [x] All 36 repo tests pass (including existing modules)
- [x] In-game verification with Minecraft Paper server + bots confirmed PvP attribution, death penalty, streaks, and leaderboard
- [ ] Manual verification of on-death hook edge cases (suicide detection, concurrent kills)