### PR TITLE
feat: multi-instance support with INSTANCE_ID port offsets

### DIFF
--- a/.claude/skills/takaro-module-dev/SKILL.md
+++ b/.claude/skills/takaro-module-dev/SKILL.md
@@ -249,8 +249,8 @@ Test helpers live in `test/helpers/`:
 ### Manual test loop (for debugging or ad-hoc verification)
 
 1. **Ensure services are running**: `docker compose up -d paper bot`
-2. **Create a test bot**: `curl -X POST http://localhost:3101/bots -H 'Content-Type: application/json' -d '{"name":"tester"}'`
-3. **Wait for connection**: `sleep 5 && curl http://localhost:3101/status`
+2. **Create a test bot**: `curl -X POST http://localhost:${BOT_PORT:-3101}/bots -H 'Content-Type: application/json' -d '{"name":"tester"}'`
+3. **Wait for connection**: `sleep 5 && curl http://localhost:${BOT_PORT:-3101}/status`
 4. **Trigger the module** (varies by component type):
    - Command: Send via bot chat
    - Hook: Trigger the game event (via bot action or RCON)
@@ -321,14 +321,14 @@ This phase applies during `/verify`, manual review, or any final check. Never sk
 3. **Create a bot and run every command**:
    ```bash
    # Create bot
-   curl -X POST http://localhost:3101/bots -H 'Content-Type: application/json' -d '{"name":"tester"}'
+   curl -X POST http://localhost:${BOT_PORT:-3101}/bots -H 'Content-Type: application/json' -d '{"name":"tester"}'
    sleep 5
 
    # Get the command prefix for this game server
    bash scripts/takaro-api.sh GET /settings?keys=commandPrefix&gameServerId=<id>
 
    # Run each command via bot chat
-   curl -X POST http://localhost:3101/bot/tester/chat -H 'Content-Type: application/json' \
+   curl -X POST http://localhost:${BOT_PORT:-3101}/bot/tester/chat -H 'Content-Type: application/json' \
      -d '{"message":"/fund 50"}'
    sleep 3
 
@@ -340,7 +340,7 @@ This phase applies during `/verify`, manual review, or any final check. Never sk
 
 5. **Clean up**:
    ```bash
-   curl -X DELETE http://localhost:3101/bots/tester
+   curl -X DELETE http://localhost:${BOT_PORT:-3101}/bots/tester
    ```
 
 ### What counts as verified
@@ -352,7 +352,7 @@ This phase applies during `/verify`, manual review, or any final check. Never sk
 
 ### When exerciser/verify agents encounter this repo
 
-If you are a verification agent (cata-exerciser or similar): this repo's "app" is the Minecraft Paper server + Takaro platform. To exercise a module, use the bot service at `http://localhost:3101` to create bots and trigger commands. Check `references/bot-api.md` for the full bot HTTP API. Do NOT skip with "no app to exercise."
+If you are a verification agent (cata-exerciser or similar): this repo's "app" is the Minecraft Paper server + Takaro platform. To exercise a module, use the bot service at `http://localhost:${BOT_PORT:-3101}` (check `.env` for `BOT_PORT`) to create bots and trigger commands. Check `references/bot-api.md` for the full bot HTTP API. Do NOT skip with "no app to exercise."
 
 ## Phase 6: Debugging
 

--- a/.claude/skills/takaro-module-dev/references/bot-api.md
+++ b/.claude/skills/takaro-module-dev/references/bot-api.md
@@ -1,8 +1,8 @@
 # Bot API Reference
 
-The bot service runs on port 3101 and provides an HTTP API for creating and controlling Minecraft player bots for testing.
+The bot service provides an HTTP API for creating and controlling Minecraft player bots for testing. The port is configured by `BOT_PORT` in `.env` (default 3101).
 
-**Base URL**: `http://localhost:3101`
+**Base URL**: `http://localhost:${BOT_PORT:-3101}`
 
 All POST endpoints require `Content-Type: application/json` header.
 
@@ -108,21 +108,21 @@ Returns: `[{name, count, slot, displayName}, ...]`
 
 ```bash
 # Create a bot
-curl -X POST http://localhost:3101/bots \
+curl -X POST http://localhost:${BOT_PORT:-3101}/bots \
   -H 'Content-Type: application/json' \
   -d '{"name":"tester"}'
 
 # Wait for connection
 sleep 5
-curl http://localhost:3101/status
+curl http://localhost:${BOT_PORT:-3101}/status
 
 # Trigger a command
-curl -X POST http://localhost:3101/bot/tester/chat \
+curl -X POST http://localhost:${BOT_PORT:-3101}/bot/tester/chat \
   -H 'Content-Type: application/json' \
   -d '{"message":"/greet World"}'
 
 # Clean up
-curl -X DELETE http://localhost:3101/bots/tester
+curl -X DELETE http://localhost:${BOT_PORT:-3101}/bots/tester
 ```
 
 ## Troubleshooting

--- a/.claude/skills/takaro-module-dev/references/testing-methodology.md
+++ b/.claude/skills/takaro-module-dev/references/testing-methodology.md
@@ -197,7 +197,7 @@ Each test suite gets its own mock game server with a unique `identityToken`. Thi
 
 1. **Services running**: `docker compose up -d paper bot`
 2. **Paper server ready**: Check `docker compose logs --tail=5 paper` — look for "Done" message
-3. **Bot service healthy**: `curl http://localhost:3101/status`
+3. **Bot service healthy**: `curl http://localhost:${BOT_PORT:-3101}/status`
 4. **Module installed**: Verify via Takaro API
 5. **Command prefix known**: Fetch from settings API — never assume
 
@@ -205,16 +205,16 @@ Each test suite gets its own mock game server with a unique `identityToken`. Thi
 
 ```bash
 # 1. Create a bot
-curl -X POST http://localhost:3101/bots \
+curl -X POST http://localhost:${BOT_PORT:-3101}/bots \
   -H 'Content-Type: application/json' \
   -d '{"name":"tester"}'
 
 # 2. Wait for connection
 sleep 5
-curl http://localhost:3101/status
+curl http://localhost:${BOT_PORT:-3101}/status
 
 # 3. Send the command (use the correct prefix!)
-curl -X POST http://localhost:3101/bot/tester/chat \
+curl -X POST http://localhost:${BOT_PORT:-3101}/bot/tester/chat \
   -H 'Content-Type: application/json' \
   -d '{"message":"+commandname arg1 arg2"}'
 
@@ -230,7 +230,7 @@ bash scripts/takaro-api.sh POST /event/search '{
 }'
 
 # 6. Clean up
-curl -X DELETE http://localhost:3101/bots/tester
+curl -X DELETE http://localhost:${BOT_PORT:-3101}/bots/tester
 ```
 
 ### Testing Hooks

--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,14 @@ TAKARO_REGISTRATION_TOKEN=your-registration-token-here
 TAKARO_MC_IDENTITY_TOKEN=unique-mc-identity
 RCON_PASSWORD=takaro123
 TAKARO_WS_URL=wss://connect.takaro.io
+TAKARO_PLUGIN_VERSION=0.0.5
+
+# Multi-instance support
+# Set INSTANCE_ID (0-9) to run multiple clones simultaneously.
+# Then run: source scripts/instance-env.sh
+# This auto-sets the port vars below based on INSTANCE_ID.
+INSTANCE_ID=0
+MC_PORT=25665
+RCON_PORT=25675
+BOT_PORT=3101
+REDIS_PORT=6379

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ docker compose up -d paper bot redis
 # See the takaro-module-dev skill for detailed steps
 ```
 
-**For verification agents**: This repo's "app" is the Minecraft server + Takaro. Use the bot service at `http://localhost:3101` to exercise modules. See `references/bot-api.md` for the API.
+**For verification agents**: This repo's "app" is the Minecraft server + Takaro. Use the bot service at `http://localhost:${BOT_PORT:-3101}` to exercise modules. See `references/bot-api.md` for the API. Check `.env` for the actual `BOT_PORT` value.
 
 ## Module Development
 
@@ -61,5 +61,5 @@ Module code lives locally in `modules/` as editable files, then gets pushed to T
 - **`npm run module:to-json`** — Convert local module dir to Takaro import JSON (calls compiled `dist/scripts/module-to-json.js`)
 - **`npm run module:from-json`** — Convert Takaro export JSON to local module dir (calls compiled `dist/scripts/json-to-module.js`)
 - **`scripts/download-plugin.sh`** — Download the Takaro Minecraft plugin
-- **Bot service** (port 3101) — Create and control Minecraft bots for testing
+- **Bot service** (port `BOT_PORT`, default 3101) — Create and control Minecraft bots for testing
 - **RCON** — `docker compose exec paper rcon-cli <command>`

--- a/README.md
+++ b/README.md
@@ -27,6 +27,23 @@ cd ai-module-writer
 cp .env.example .env
 ```
 
+### Running Multiple Instances
+
+To run multiple clones simultaneously (e.g., `ai-module-writer-1` through `ai-module-writer-5`), set a unique `INSTANCE_ID` (0-9) in each clone's `.env` file, then generate the port offsets:
+
+```bash
+# In each clone, set the INSTANCE_ID and generate ports
+scripts/instance-env.sh 2 >> .env   # appends MC_PORT=25667, BOT_PORT=3103, etc.
+```
+
+| Instance | MC Port | RCON Port | Bot Port | Redis Port |
+|----------|---------|-----------|----------|------------|
+| 0 | 25665 | 25675 | 3101 | 6379 |
+| 1 | 25666 | 25676 | 3102 | 6380 |
+| 2 | 25667 | 25677 | 3103 | 6381 |
+
+Each clone also needs a unique `TAKARO_MC_IDENTITY_TOKEN` in `.env`.
+
 ### Configure your `.env` file
 
 You need:
@@ -71,8 +88,8 @@ claude
 ## How it Works
 
 The Docker containers run:
-- **Paper Minecraft server** (port 25665/25675) — Real Minecraft server for in-game testing
-- **Mineflayer bot service** (port 3101) — HTTP-controlled bots for simulating players
+- **Paper Minecraft server** (port `MC_PORT`/`RCON_PORT`, default 25665/25675) — Real Minecraft server for in-game testing
+- **Mineflayer bot service** (port `BOT_PORT`, default 3101) — HTTP-controlled bots for simulating players
 
 This repository includes:
 - **Auth scripts** (`scripts/`) — Authenticate with the Takaro API and make curl calls
@@ -83,10 +100,10 @@ Modules are created and managed directly in Takaro via the API — no module cod
 
 ## Using the Bot
 
-The bot service provides an HTTP API on port 3101 for creating and controlling Minecraft bots:
+The bot service provides an HTTP API (port configured by `BOT_PORT` in `.env`, default 3101) for creating and controlling Minecraft bots:
 
 ```bash
-# Create a bot
+# Create a bot (replace 3101 with your BOT_PORT if different)
 curl -X POST http://localhost:3101/bots \
   -H 'Content-Type: application/json' \
   -d '{"name": "player1"}'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ services:
   paper:
     image: itzg/minecraft-server
     ports:
-      - "25665:25565"
-      - "25675:25575"
+      - "${MC_PORT:-25665}:25565"
+      - "${RCON_PORT:-25675}:25575"
     environment:
       - EULA=TRUE
       - TYPE=PAPER
@@ -14,6 +14,8 @@ services:
       - TAKARO_REGISTRATION_TOKEN=${TAKARO_REGISTRATION_TOKEN}
       - TAKARO_IDENTITY_TOKEN=${TAKARO_MC_IDENTITY_TOKEN:-nca-ai-paper}
       - TAKARO_WS_URL=${TAKARO_WS_URL:-wss://connect.takaro.io}
+      - PLUGINS=https://github.com/gettakaro/takaro-minecraft/releases/download/${TAKARO_PLUGIN_VERSION:-0.0.5}/takaro-paper-${TAKARO_PLUGIN_VERSION:-0.0.5}.jar
+      - REMOVE_OLD_PLUGINS=TRUE
     volumes:
       - ./_data/paper:/data
     restart: unless-stopped
@@ -21,7 +23,7 @@ services:
   bot:
     build: ./bot
     ports:
-      - "3101:3001"
+      - "${BOT_PORT:-3101}:3001"
     environment:
       - MC_HOST=paper
       - MC_PORT=25565
@@ -34,5 +36,5 @@ services:
   redis:
     image: redis:7-alpine
     ports:
-      - "6379:6379"
+      - "${REDIS_PORT:-6379}:6379"
     restart: unless-stopped

--- a/scripts/instance-env.sh
+++ b/scripts/instance-env.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Compute port env vars from INSTANCE_ID.
+# Usage:
+#   INSTANCE_ID=2 source scripts/instance-env.sh   # export into current shell
+#   scripts/instance-env.sh 3                       # print .env lines to stdout
+
+set -euo pipefail
+
+ID="${1:-${INSTANCE_ID:-0}}"
+
+if ! [[ "$ID" =~ ^[0-9]$ ]]; then
+  echo "Error: INSTANCE_ID must be 0-9, got '$ID'" >&2
+  exit 1
+fi
+
+MC_PORT=$((25665 + ID))
+RCON_PORT=$((25675 + ID))
+BOT_PORT=$((3101 + ID))
+REDIS_PORT=$((6379 + ID))
+
+# If sourced, export the vars. If executed, print .env lines.
+if [[ "${BASH_SOURCE[0]}" != "${0}" ]]; then
+  export INSTANCE_ID="$ID"
+  export MC_PORT RCON_PORT BOT_PORT REDIS_PORT
+  echo "Instance $ID: MC=$MC_PORT RCON=$RCON_PORT Bot=$BOT_PORT Redis=$REDIS_PORT"
+else
+  cat <<EOF
+INSTANCE_ID=$ID
+MC_PORT=$MC_PORT
+RCON_PORT=$RCON_PORT
+BOT_PORT=$BOT_PORT
+REDIS_PORT=$REDIS_PORT
+EOF
+fi


### PR DESCRIPTION
## Summary
- Parameterize all host ports in docker-compose.yml via env vars (`MC_PORT`, `RCON_PORT`, `BOT_PORT`, `REDIS_PORT`) with backward-compatible defaults
- Add `scripts/instance-env.sh` helper to compute port offsets from a single `INSTANCE_ID` (0-9)
- Auto-download the Takaro Minecraft plugin on every Paper boot via the itzg `PLUGINS` env var
- Update all documentation to reference configurable `BOT_PORT`

## Test plan
- [x] `docker compose config` resolves default ports correctly
- [x] `docker compose config` with `INSTANCE_ID=2` offset ports shows correct values
- [x] Services start and bind to offset ports (verified MC:25667, RCON:25677, Bot:3103, Redis:6381)
- [x] Bot service responds on offset port
- [x] RCON works through offset port
- [x] Bot connects to Minecraft and appears in-game
- [x] Takaro plugin auto-downloads and loads on boot
- [x] `yamllint` passes on docker-compose.yml
- [x] Automated tests pass (afk-kick suite)