### PR TITLE
Add lottery module with daily draws and prize pools

### DIFF
--- a/modules/lottery/config.json
+++ b/modules/lottery/config.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "ticketPrice": {
+      "type": "number",
+      "default": 10,
+      "minimum": 1,
+      "description": "Cost per ticket in currency"
+    },
+    "profitMargin": {
+      "type": "number",
+      "default": 0.1,
+      "minimum": 0,
+      "maximum": 0.99,
+      "description": "Fraction of the pot the server keeps (0 = no server fee, 0.99 = server keeps 99%)"
+    },
+    "maxTicketsPerPlayer": {
+      "type": "number",
+      "default": 100,
+      "minimum": 1,
+      "description": "Maximum tickets a single player can hold for one draw"
+    },
+    "minimumParticipants": {
+      "type": "number",
+      "default": 2,
+      "minimum": 2,
+      "description": "Minimum number of unique players required to proceed with the draw"
+    },
+    "announceTicketPurchases": {
+      "type": "boolean",
+      "default": false,
+      "description": "Whether to broadcast ticket purchases to all players"
+    },
+    "rolloverOnCancel": {
+      "type": "boolean",
+      "default": false,
+      "description": "When true, pot rolls over to the next draw instead of refunding players on cancellation"
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/modules/lottery/module.json
+++ b/modules/lottery/module.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-lottery",
+  "description": "Lottery — players buy tickets with in-game currency and a daily draw picks a weighted random winner. Prize pool grows with each ticket purchase.",
+  "version": "latest",
+  "supportedGames": ["all"]
+}

--- a/modules/lottery/permissions.json
+++ b/modules/lottery/permissions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "permission": "LOTTERY_BUY",
+    "friendlyName": "Buy Lottery Tickets",
+    "description": "Allows a player to buy lottery tickets",
+    "canHaveCount": false
+  },
+  {
+    "permission": "LOTTERY_VIEW_TICKETS",
+    "friendlyName": "View Lottery Tickets",
+    "description": "Allows a player to view their current ticket count",
+    "canHaveCount": false
+  }
+]

--- a/modules/lottery/src/commands/buy-ticket/command.json
+++ b/modules/lottery/src/commands/buy-ticket/command.json
@@ -1,0 +1,13 @@
+{
+  "trigger": "buyticket",
+  "description": "Buy lottery tickets",
+  "helpText": "Buy one or more lottery tickets for the current draw. Usage: buyticket <amount>",
+  "arguments": [
+    {
+      "name": "amount",
+      "type": "number",
+      "helpText": "Number of tickets to buy",
+      "position": 0
+    }
+  ]
+}

--- a/modules/lottery/src/commands/buy-ticket/index.js
+++ b/modules/lottery/src/commands/buy-ticket/index.js
@@ -1,0 +1,99 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getPot,
+  setPot,
+  getPlayerTickets,
+  setPlayerTickets,
+} from './lottery-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'LOTTERY_BUY')) {
+    throw new TakaroUserError('You do not have permission to buy lottery tickets.');
+  }
+
+  const amount = args.amount;
+  const config = mod.userConfig;
+  const moduleId = mod.moduleId;
+
+  if (amount === undefined || amount === null) {
+    throw new TakaroUserError('Usage: buyticket <amount> — Amount must be a positive whole number.');
+  }
+
+  if (!Number.isInteger(amount) || amount < 1) {
+    throw new TakaroUserError('Usage: buyticket <amount> — Amount must be a positive whole number.');
+  }
+
+  const ticketPrice = config.ticketPrice;
+  const maxTicketsPerPlayer = config.maxTicketsPerPlayer;
+
+  const currentTickets = await getPlayerTickets(gameServerId, moduleId, pog.playerId);
+
+  if (currentTickets + amount > maxTicketsPerPlayer) {
+    const remaining = maxTicketsPerPlayer - currentTickets;
+    throw new TakaroUserError(
+      `You can only hold ${maxTicketsPerPlayer} tickets per draw. You have ${currentTickets} and tried to buy ${amount} more. You can buy ${remaining} more.`,
+    );
+  }
+
+  // The command cost system auto-deducts 1x ticketPrice before the handler runs.
+  // The handler only needs to deduct the ADDITIONAL cost for extra tickets beyond the first.
+  const totalCost = amount * ticketPrice;
+  const additionalCost = (amount - 1) * ticketPrice;
+
+  // Fast-fail currency check: pog.currency reflects the balance at dispatch time (before command cost auto-deduction).
+  // Check total cost against pre-deduction balance to fast-fail.
+  if (pog.currency < additionalCost + ticketPrice) {
+    throw new TakaroUserError(
+      `You don't have enough currency. Buying ${amount} ticket${amount > 1 ? 's' : ''} costs ${totalCost} currency. You have ${pog.currency} currency.`,
+    );
+  }
+
+  async function deductPlayerCurrency(deductAmount) {
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerDeductCurrency(gameServerId, pog.playerId, {
+        currency: deductAmount,
+      });
+      return true;
+    } catch (deductErr) {
+      console.error(
+        `Lottery: currency deduction failed for player ${player.name} (additionalCost=${deductAmount}). Pot and tickets already updated. Error: ${deductErr}`,
+      );
+      return false;
+    }
+  }
+
+  // Update state BEFORE deducting currency (player keeps money if state update fails).
+  // The pot gets the full amount * ticketPrice because command cost (1x) + additional ((N-1)x) = N*ticketPrice total.
+  const newTickets = currentTickets + amount;
+  const currentPot = await getPot(gameServerId, moduleId);
+  const newPot = currentPot + amount * ticketPrice;
+
+  console.log(
+    `Lottery: player=${player.name}, buying ${amount} tickets, currentTickets=${currentTickets}, newTickets=${newTickets}, previousPot=${currentPot}, newPot=${newPot}, totalCost=${totalCost}`,
+  );
+
+  await setPlayerTickets(gameServerId, moduleId, pog.playerId, newTickets);
+  await setPot(gameServerId, moduleId, newPot);
+
+  // Deduct only the ADDITIONAL cost beyond the 1x auto-deducted by the command cost system.
+  let deductionSucceeded = true;
+  if (additionalCost > 0) {
+    deductionSucceeded = await deductPlayerCurrency(additionalCost);
+  }
+
+  const deductionNote = deductionSucceeded ? '' : ' (Note: currency deduction encountered an issue — please contact an admin)';
+  await pog.pm(
+    `You bought ${amount} ticket${amount > 1 ? 's' : ''} for ${totalCost} currency. You now have ${newTickets} ticket${newTickets > 1 ? 's' : ''} in this draw. Current pot: ${newPot}.${deductionNote}`,
+  );
+
+  if (config.announceTicketPurchases) {
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `${player.name} bought ${amount} lottery ticket${amount > 1 ? 's' : ''}! Current pot: ${newPot}.`,
+      opts: {},
+    });
+  }
+}
+
+await main();

--- a/modules/lottery/src/commands/lottery-info/command.json
+++ b/modules/lottery/src/commands/lottery-info/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "lotteryinfo",
+  "description": "View current lottery status",
+  "helpText": "Shows the current pot, participant count, total tickets, and ticket price for the upcoming draw.",
+  "arguments": []
+}

--- a/modules/lottery/src/commands/lottery-info/index.js
+++ b/modules/lottery/src/commands/lottery-info/index.js
@@ -1,0 +1,33 @@
+import { data } from '@takaro/helpers';
+import { getPot, getRollover, getAllTicketEntries } from './lottery-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  const [pot, rollover, entries] = await Promise.all([
+    getPot(gameServerId, moduleId),
+    getRollover(gameServerId, moduleId),
+    getAllTicketEntries(gameServerId, moduleId),
+  ]);
+
+  const participantCount = entries.length;
+  const totalTickets = entries.reduce((sum, e) => sum + e.tickets, 0);
+  const totalPot = pot + rollover;
+
+  console.log(`lottery-info: pot=${pot}, rollover=${rollover}, participants=${participantCount}, totalTickets=${totalTickets}`);
+
+  if (participantCount === 0) {
+    await pog.pm(`Lottery: No participants yet. Ticket price: ${config.ticketPrice}. Use the buyticket command to participate!`);
+  } else {
+    const estimatedPrize = Math.floor(totalPot * (1 - config.profitMargin));
+    // Lead with the prize, then details
+    await pog.pm(`Lottery: Estimated prize this draw: ${estimatedPrize} currency.`);
+    await pog.pm(`Lottery: Pot: ${totalPot}${rollover > 0 ? ` (incl. ${rollover} rollover)` : ''} | Participants: ${participantCount} | Total tickets: ${totalTickets} | Ticket price: ${config.ticketPrice}.`);
+    await pog.pm(`Lottery: The draw runs on a scheduled timer.`);
+  }
+}
+
+await main();

--- a/modules/lottery/src/commands/next-draw/command.json
+++ b/modules/lottery/src/commands/next-draw/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "nextdraw",
+  "description": "See when the next lottery draw is",
+  "helpText": "Shows how long until the next lottery draw at midnight UTC.",
+  "arguments": []
+}

--- a/modules/lottery/src/commands/next-draw/index.js
+++ b/modules/lottery/src/commands/next-draw/index.js
@@ -1,0 +1,24 @@
+import { data } from '@takaro/helpers';
+
+async function main() {
+  const { pog } = data;
+
+  const now = new Date();
+  const nextMidnightUtc = new Date(Date.UTC(
+    now.getUTCFullYear(),
+    now.getUTCMonth(),
+    now.getUTCDate() + 1,
+    0, 0, 0, 0,
+  ));
+
+  const msUntilDraw = nextMidnightUtc.getTime() - now.getTime();
+  const totalMinutes = Math.floor(msUntilDraw / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  console.log(`nextdraw: hours=${hours}, minutes=${minutes}`);
+
+  await pog.pm(`Next lottery draw in ${hours} hour${hours !== 1 ? 's' : ''} and ${minutes} minute${minutes !== 1 ? 's' : ''}.`);
+}
+
+await main();

--- a/modules/lottery/src/commands/view-tickets/command.json
+++ b/modules/lottery/src/commands/view-tickets/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "viewtickets",
+  "description": "View your current lottery ticket count",
+  "helpText": "Shows how many tickets you currently hold for the upcoming draw.",
+  "arguments": []
+}

--- a/modules/lottery/src/commands/view-tickets/index.js
+++ b/modules/lottery/src/commands/view-tickets/index.js
@@ -1,0 +1,23 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { getPlayerTickets } from './lottery-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+
+  if (!checkPermission(pog, 'LOTTERY_VIEW_TICKETS')) {
+    throw new TakaroUserError('You do not have permission to view lottery tickets.');
+  }
+
+  const moduleId = mod.moduleId;
+  const tickets = await getPlayerTickets(gameServerId, moduleId, pog.playerId);
+
+  console.log(`viewtickets: playerId=${pog.playerId}, tickets=${tickets}`);
+
+  if (tickets === 0) {
+    await pog.pm('You have no tickets in the current draw. Use the buyticket command to participate!');
+  } else {
+    await pog.pm(`You have ${tickets} ticket${tickets > 1 ? 's' : ''} in the current draw.`);
+  }
+}
+
+await main();

--- a/modules/lottery/src/cronjobs/draw-lottery/cronjob.json
+++ b/modules/lottery/src/cronjobs/draw-lottery/cronjob.json
@@ -1,0 +1,4 @@
+{
+  "temporalValue": "0 0 * * *",
+  "description": "Daily lottery draw at midnight UTC — picks a weighted random winner from ticket holders"
+}

--- a/modules/lottery/src/cronjobs/draw-lottery/index.js
+++ b/modules/lottery/src/cronjobs/draw-lottery/index.js
@@ -1,0 +1,183 @@
+import { data, takaro } from '@takaro/helpers';
+import {
+  getPot,
+  setPot,
+  getRollover,
+  setRollover,
+  getDrawNumber,
+  setDrawNumber,
+  getAllTicketEntries,
+  deleteAllTickets,
+} from './lottery-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  const [entries, pot, rollover, drawNumber] = await Promise.all([
+    getAllTicketEntries(gameServerId, moduleId),
+    getPot(gameServerId, moduleId),
+    getRollover(gameServerId, moduleId),
+    getDrawNumber(gameServerId, moduleId),
+  ]);
+
+  const participantCount = entries.length;
+  const totalTickets = entries.reduce((sum, e) => sum + e.tickets, 0);
+  const totalPot = pot + rollover;
+
+  console.log(
+    `draw-lottery: drawNumber=${drawNumber}, participants=${participantCount}, totalTickets=${totalTickets}, pot=${pot}, rollover=${rollover}, totalPot=${totalPot}`,
+  );
+
+  if (participantCount < config.minimumParticipants) {
+    console.log(
+      `draw-lottery: cancelling draw — only ${participantCount} participant(s), need ${config.minimumParticipants}`,
+    );
+
+    if (config.rolloverOnCancel) {
+      // Roll over the entire pot to the next draw
+      await setRollover(gameServerId, moduleId, totalPot);
+      await setPot(gameServerId, moduleId, 0);
+      await deleteAllTickets(gameServerId, moduleId);
+
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `The lottery draw was cancelled — not enough participants (need ${config.minimumParticipants}, got ${participantCount}). The pot of ${totalPot} rolls over to the next draw! Tickets do not carry over — buy new tickets for the next draw!`,
+        opts: {},
+      });
+    } else {
+      // Refund all players; track any failures
+      let refundFailures = 0;
+      let totalRefunded = 0;
+      const failedPlayerIds = [];
+      for (const entry of entries) {
+        const refund = entry.tickets * config.ticketPrice;
+        try {
+          await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, entry.playerId, {
+            currency: refund,
+          });
+          totalRefunded += refund;
+          console.log(`draw-lottery: refunded ${refund} to player ${entry.playerId}`);
+        } catch (refundErr) {
+          refundFailures++;
+          failedPlayerIds.push(entry.playerId);
+          console.error(`draw-lottery: failed to refund player ${entry.playerId} (refund=${refund}). Error: ${refundErr}`);
+        }
+      }
+
+      // Only delete ticket records for players who were successfully refunded
+      if (refundFailures === 0) {
+        await setPot(gameServerId, moduleId, 0);
+        await setRollover(gameServerId, moduleId, 0);
+        await deleteAllTickets(gameServerId, moduleId);
+
+        await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+          message: `The lottery draw was cancelled — not enough participants (need ${config.minimumParticipants}, got ${participantCount}). All tickets have been refunded.`,
+          opts: {},
+        });
+      } else {
+        // Partial refund failure: decrement pot by the amount actually refunded.
+        // The remaining pot already includes the rollover amount, so zero rollover to prevent double-counting on next draw.
+        const remainingPot = totalPot - totalRefunded;
+        await setRollover(gameServerId, moduleId, 0);
+        await setPot(gameServerId, moduleId, remainingPot);
+        console.error(`draw-lottery: ${refundFailures} refund(s) failed for players: ${failedPlayerIds.join(', ')}. Pot reduced by ${totalRefunded} (refunded amount). Remaining pot: ${remainingPot}. Ticket records preserved for manual recovery.`);
+
+        await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+          message: `The lottery draw was cancelled — not enough participants. Refunds were partially processed (${entries.length - refundFailures}/${entries.length} succeeded). Please contact an admin if you did not receive your refund.`,
+          opts: {},
+        });
+      }
+    }
+
+    return;
+  }
+
+  // Weighted random winner selection
+  // Walk entries, pick a random number in [0, totalTickets), subtract tickets until we reach zero
+  const randomTarget = Math.floor(Math.random() * totalTickets);
+  let accumulated = 0;
+  let winner = null;
+
+  for (const entry of entries) {
+    accumulated += entry.tickets;
+    if (randomTarget < accumulated) {
+      winner = entry;
+      break;
+    }
+  }
+
+  if (!winner) {
+    // Fallback: pick the last entry (shouldn't happen with correct logic)
+    winner = entries[entries.length - 1];
+    console.error(`draw-lottery: winner selection fallback triggered. randomTarget=${randomTarget}, totalTickets=${totalTickets}`);
+  }
+
+  const prize = Math.max(1, Math.floor(totalPot * (1 - config.profitMargin)));
+  const newDrawNumber = drawNumber + 1;
+
+  console.log(
+    `draw-lottery: winner=${winner.playerId}, tickets=${winner.tickets}/${totalTickets}, prize=${prize}, drawNumber=${newDrawNumber}`,
+  );
+
+  // Award the prize; only reset state if award succeeds
+  let prizeAwarded = false;
+  try {
+    await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, winner.playerId, {
+      currency: prize,
+    });
+    prizeAwarded = true;
+  } catch (prizeErr) {
+    console.error(`draw-lottery: CRITICAL — failed to award prize to winner ${winner.playerId} (prize=${prize}). State NOT reset to allow manual recovery. Error: ${prizeErr}`);
+  }
+
+  if (!prizeAwarded) {
+    // Do not reset state — preserve for manual admin recovery
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `LOTTERY ERROR: The draw for Draw #${newDrawNumber} could not be completed — prize award failed. Please contact an admin for manual resolution.`,
+      opts: {},
+    });
+    return;
+  }
+
+  // Reset state only after successful prize award
+  try {
+    await setDrawNumber(gameServerId, moduleId, newDrawNumber);
+  } catch (err) {
+    console.error(`draw-lottery: failed to setDrawNumber. Error: ${err}`);
+  }
+  try {
+    await setPot(gameServerId, moduleId, 0);
+  } catch (err) {
+    console.error(`draw-lottery: failed to setPot to 0. Error: ${err}`);
+  }
+  try {
+    await setRollover(gameServerId, moduleId, 0);
+  } catch (err) {
+    console.error(`draw-lottery: failed to setRollover to 0. Error: ${err}`);
+  }
+  try {
+    await deleteAllTickets(gameServerId, moduleId);
+  } catch (err) {
+    console.error(`draw-lottery: failed to deleteAllTickets. Error: ${err}`);
+  }
+
+  // Look up winner's player name for the broadcast
+  let winnerName = 'Unknown Player';
+  try {
+    const playerResult = await takaro.player.playerControllerGetOne(winner.playerId);
+    if (playerResult.data.data && playerResult.data.data.name) {
+      winnerName = playerResult.data.data.name;
+    }
+  } catch (lookupErr) {
+    console.error(`draw-lottery: failed to look up winner name for ${winner.playerId}. Using "Unknown Player". Error: ${lookupErr}`);
+  }
+
+  // Lead with player name, then prize details
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `*** LOTTERY DRAW *** Congratulations to ${winnerName} for winning ${prize} currency! (Draw #${newDrawNumber} — held ${winner.tickets}/${totalTickets} tickets) See you in the next draw!`,
+    opts: {},
+  });
+}
+
+await main();

--- a/modules/lottery/src/functions/lottery-helpers.js
+++ b/modules/lottery/src/functions/lottery-helpers.js
@@ -1,0 +1,186 @@
+import { takaro } from '@takaro/helpers';
+
+export const LOTTERY_POT_KEY = 'lottery_pot';
+export const LOTTERY_DRAW_NUMBER_KEY = 'lottery_draw_number';
+export const LOTTERY_ROLLOVER_KEY = 'lottery_rollover';
+export const LOTTERY_TICKETS_KEY = 'lottery_tickets';
+
+/**
+ * Generic variable read helper. Returns the variable record or null if not found.
+ */
+export async function findVariable(gameServerId, moduleId, key, playerId) {
+  const filters = {
+    key: [key],
+    gameServerId: [gameServerId],
+    moduleId: [moduleId],
+  };
+  if (playerId) {
+    filters.playerId = [playerId];
+  }
+  const res = await takaro.variable.variableControllerSearch({ filters });
+  return res.data.data.length > 0 ? res.data.data[0] : null;
+}
+
+/**
+ * Generic variable write helper. Creates if not existing, updates if existing.
+ */
+export async function writeVariable(gameServerId, moduleId, key, value, playerId) {
+  const existing = await findVariable(gameServerId, moduleId, key, playerId);
+  const serialized = JSON.stringify(value);
+  if (existing) {
+    await takaro.variable.variableControllerUpdate(existing.id, { value: serialized });
+  } else {
+    const payload = { key, value: serialized, gameServerId, moduleId };
+    if (playerId) payload.playerId = playerId;
+    await takaro.variable.variableControllerCreate(payload);
+  }
+}
+
+/**
+ * Generic variable delete helper.
+ */
+export async function deleteVariable(gameServerId, moduleId, key, playerId) {
+  const existing = await findVariable(gameServerId, moduleId, key, playerId);
+  if (existing) {
+    await takaro.variable.variableControllerDelete(existing.id);
+  }
+}
+
+// ---- Global state helpers ----
+
+export async function getPot(gameServerId, moduleId) {
+  const variable = await findVariable(gameServerId, moduleId, LOTTERY_POT_KEY);
+  if (!variable) return 0;
+  try {
+    const val = Math.floor(JSON.parse(variable.value));
+    return isNaN(val) ? 0 : val;
+  } catch (err) {
+    console.error(`lottery-helpers: getPot failed to parse stored value, returning 0. Error: ${err}`);
+    return 0;
+  }
+}
+
+export async function setPot(gameServerId, moduleId, amount) {
+  if (typeof amount !== 'number' || isNaN(amount)) amount = 0;
+  await writeVariable(gameServerId, moduleId, LOTTERY_POT_KEY, Math.floor(amount));
+}
+
+export async function getRollover(gameServerId, moduleId) {
+  const variable = await findVariable(gameServerId, moduleId, LOTTERY_ROLLOVER_KEY);
+  if (!variable) return 0;
+  try {
+    const val = Math.floor(JSON.parse(variable.value));
+    return isNaN(val) ? 0 : val;
+  } catch (err) {
+    console.error(`lottery-helpers: getRollover failed to parse stored value, returning 0. Error: ${err}`);
+    return 0;
+  }
+}
+
+export async function setRollover(gameServerId, moduleId, amount) {
+  if (typeof amount !== 'number' || isNaN(amount)) amount = 0;
+  await writeVariable(gameServerId, moduleId, LOTTERY_ROLLOVER_KEY, Math.floor(amount));
+}
+
+export async function getDrawNumber(gameServerId, moduleId) {
+  const variable = await findVariable(gameServerId, moduleId, LOTTERY_DRAW_NUMBER_KEY);
+  if (!variable) return 0;
+  try {
+    const val = Math.floor(JSON.parse(variable.value));
+    return isNaN(val) ? 0 : val;
+  } catch (err) {
+    console.error(`lottery-helpers: getDrawNumber failed to parse stored value, returning 0. Error: ${err}`);
+    return 0;
+  }
+}
+
+export async function setDrawNumber(gameServerId, moduleId, num) {
+  if (typeof num !== 'number' || isNaN(num)) num = 0;
+  await writeVariable(gameServerId, moduleId, LOTTERY_DRAW_NUMBER_KEY, Math.floor(num));
+}
+
+// ---- Per-player helpers ----
+
+export async function getPlayerTickets(gameServerId, moduleId, playerId) {
+  const variable = await findVariable(gameServerId, moduleId, LOTTERY_TICKETS_KEY, playerId);
+  if (!variable) return 0;
+  try {
+    const val = Math.floor(JSON.parse(variable.value));
+    return isNaN(val) ? 0 : val;
+  } catch (err) {
+    console.error(`lottery-helpers: getPlayerTickets failed to parse stored value, returning 0. Error: ${err}`);
+    return 0;
+  }
+}
+
+export async function setPlayerTickets(gameServerId, moduleId, playerId, tickets) {
+  if (typeof tickets !== 'number' || isNaN(tickets)) tickets = 0;
+  await writeVariable(gameServerId, moduleId, LOTTERY_TICKETS_KEY, Math.floor(tickets), playerId);
+}
+
+/**
+ * Paginated search for all lottery_tickets variables.
+ * Returns [{playerId, tickets, variableId}]
+ */
+export async function getAllTicketEntries(gameServerId, moduleId) {
+  const entries = [];
+  let page = 0;
+  const limit = 100;
+  while (true) {
+    if (page > 100) break;
+    const res = await takaro.variable.variableControllerSearch({
+      filters: {
+        key: [LOTTERY_TICKETS_KEY],
+        gameServerId: [gameServerId],
+        moduleId: [moduleId],
+      },
+      page,
+      limit,
+    });
+    const batch = res.data.data;
+    for (const v of batch) {
+      try {
+        const tickets = Math.floor(JSON.parse(v.value));
+        if (!isNaN(tickets) && tickets > 0 && v.playerId) {
+          entries.push({ playerId: v.playerId, tickets, variableId: v.id });
+        }
+      } catch (err) {
+        console.error(`lottery-helpers: failed to parse ticket variable ${v.id}, skipping. Error: ${err}`);
+      }
+    }
+    if (entries.length >= res.data.meta.total || batch.length < limit) break;
+    page++;
+  }
+  return entries;
+}
+
+/**
+ * Paginated delete of all lottery_tickets variables.
+ */
+export async function deleteAllTickets(gameServerId, moduleId) {
+  let deleted = 0;
+  let iterations = 0;
+  while (true) {
+    if (iterations > 100) break;
+    iterations++;
+    const res = await takaro.variable.variableControllerSearch({
+      filters: {
+        key: [LOTTERY_TICKETS_KEY],
+        gameServerId: [gameServerId],
+        moduleId: [moduleId],
+      },
+      page: 0,
+      limit: 100,
+    });
+    const batch = res.data.data;
+    if (batch.length === 0) break;
+    const results = await Promise.allSettled(batch.map(v => takaro.variable.variableControllerDelete(v.id)));
+    deleted += results.filter(r => r.status === 'fulfilled').length;
+    const rejected = results.filter(r => r.status === 'rejected');
+    if (rejected.length > 0) {
+      rejected.forEach(r => console.error(`lottery-helpers: deleteAllTickets failed to delete a ticket record. Reason: ${r.reason}`));
+    }
+    if (batch.length < 100) break;
+  }
+  console.log(`lottery-helpers: deleteAllTickets deleted ${deleted} ticket records`);
+}

--- a/modules/lottery/test/buy-ticket.test.ts
+++ b/modules/lottery/test/buy-ticket.test.ts
@@ -1,0 +1,319 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// NOTE: Tests in this suite run sequentially and share lottery state across all cases.
+// player[0] has LOTTERY_BUY; player[1] does NOT. Ticket price=10, maxTicketsPerPlayer=5.
+// Command cost auto-deducts 1x ticketPrice; handler deducts (amount-1)*ticketPrice additional.
+
+describe('lottery: /buyticket command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let buyRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy for currency operations
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 5,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: false,
+      },
+      // Set command cost=ticketPrice so the system auto-deducts 1x ticketPrice.
+      // The handler then deducts only (amount-1)*ticketPrice to avoid double-charging.
+      systemConfig: {
+        commands: {
+          'buy-ticket': {
+            cost: 10,
+          },
+        },
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Assign LOTTERY_BUY permission to player[0] only
+    buyRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY'],
+    );
+
+    // Give player[0] some starting currency (500)
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Give player[1] some currency too so command cost check passes (permission check in handler fails instead).
+    // Without currency, Takaro blocks the command at the cost check and emits a different event type.
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[1].playerId,
+      { currency: 100 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, buyRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should buy 1 ticket successfully', async () => {
+    const player = ctx.players[0]!;
+
+    // Record currency before
+    const pogBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const currencyBefore = pogBefore.data.data[0]?.currency ?? 0;
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 1`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected buyticket to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('Lottery:') && msg.includes('buying 1 tickets')),
+      `Expected log to contain "buying 1 tickets", got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify currency was deducted by exactly 10: the command cost system auto-deducts 1x ticketPrice (=10).
+    // When amount=1, additionalCost=(1-1)*10=0, so the handler deducts nothing extra.
+    const pogAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const currencyAfter = pogAfter.data.data[0]?.currency ?? 0;
+    assert.equal(
+      currencyAfter,
+      currencyBefore - 10,
+      `Expected currency to decrease by 10 (ticket price). Before: ${currencyBefore}, After: ${currencyAfter}`,
+    );
+  });
+
+  it('should buy multiple tickets with correct additional currency deduction', async () => {
+    const player = ctx.players[0]!;
+
+    // Record currency before buying 2 more
+    const pogBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const currencyBefore = pogBefore.data.data[0]?.currency ?? 0;
+
+    const before = new Date();
+
+    // Buy 2 more — player already has 1 ticket, will have 3 total.
+    // Total cost = 2 * 10 = 20: 1x ticketPrice auto-deducted by command system + (2-1)*10=10 additional deducted by handler.
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 2`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected buying multiple tickets to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('Lottery:') && msg.includes('buying 2 tickets')),
+      `Expected log to show buying 2 tickets, got: ${JSON.stringify(logMessages)}`,
+    );
+    // Verify cumulative ticket count is now 3
+    assert.ok(
+      logMessages.some((msg) => msg.includes('newTickets=3')),
+      `Expected newTickets=3 in log, got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify currency deducted: buying 2 tickets costs 20 total (10 auto-deducted by command system + 10 additional deducted by handler)
+    const pogAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const currencyAfter = pogAfter.data.data[0]?.currency ?? 0;
+    assert.equal(
+      currencyAfter,
+      currencyBefore - 20,
+      `Expected currency to decrease by 20 (2 tickets * price 10). Before: ${currencyBefore}, After: ${currencyAfter}`,
+    );
+  });
+
+  it('should deny purchase without LOTTERY_BUY permission', async () => {
+    // player[1] has no LOTTERY_BUY permission
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 1`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail without permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should reject purchase exceeding maxTicketsPerPlayer', async () => {
+    // player[0] has 3 tickets, maxTicketsPerPlayer=5, try to buy 3 more (would be 6)
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 3`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail when exceeding max tickets');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('only hold') || msg.includes('maxTicketsPerPlayer') || msg.includes('5 tickets')),
+      `Expected max tickets error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should reject purchase when player has insufficient currency', async () => {
+    // Drain player's currency and give exactly 10 (enough for 1 ticket via command cost, but not 2).
+    // With command cost=10, Takaro auto-deducts 10 before the handler runs.
+    // The handler sees original pog.currency=10 and checks 10 < (2-1)*10 + 10 = 20 → throws error.
+    const pogResult = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: {
+        gameServerId: [ctx.gameServer.id],
+        playerId: [ctx.players[0].playerId],
+      },
+    });
+    const currentCurrency = pogResult.data.data[0]?.currency ?? 0;
+    if (currentCurrency > 0) {
+      await client.playerOnGameserver.playerOnGameServerControllerDeductCurrency(
+        ctx.gameServer.id,
+        ctx.players[0].playerId,
+        { currency: currentCurrency },
+      );
+    }
+    // Give exactly 10: enough to pass the command cost check but not enough for 2 tickets total.
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 10 },
+    );
+
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    // Try to buy 2 tickets (costs 20 total — player has only 10)
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 2`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected command to fail with insufficient currency');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('enough currency')),
+      `Expected "enough currency" error message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/lottery/test/draw-lottery-rollover.test.ts
+++ b/modules/lottery/test/draw-lottery-rollover.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('lottery: draw-lottery rolloverOnCancel', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let cronjobId: string;
+  let prefix: string;
+  let buyRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with rolloverOnCancel=true, minimumParticipants=2 (only 1 player will buy)
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 100,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: true,
+      },
+      // Set command cost=ticketPrice so the system auto-deducts 1x ticketPrice.
+      systemConfig: {
+        commands: {
+          'buy-ticket': {
+            cost: 10,
+          },
+        },
+      },
+    });
+
+    const cronjob = mod.latestVersion.cronJobs[0];
+    if (!cronjob) throw new Error('Expected at least one cronjob in lottery module');
+    cronjobId = cronjob.id;
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    buyRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY'],
+    );
+
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, buyRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should roll over pot when rolloverOnCancel=true and insufficient participants', async () => {
+    // player[0] buys 2 tickets (pot = 20)
+    const buyBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 2`,
+      playerId: ctx.players[0].playerId,
+    });
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buyBefore,
+      timeout: 30000,
+    });
+
+    // Record player[0]'s currency before draw (should NOT be refunded)
+    const pogBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const currencyBeforeDraw = pogBefore.data.data[0]?.currency ?? 0;
+
+    // Trigger the draw — 1 participant, need 2, rolloverOnCancel=true
+    const drawBefore = new Date();
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx.gameServer.id,
+      cronjobId,
+      moduleId,
+    });
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: drawBefore,
+      timeout: 30000,
+    });
+
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    const success = meta?.result?.success ?? false;
+    const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+
+    assert.equal(success, true, `Expected draw cronjob to succeed on cancel, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('cancelling draw')),
+      `Expected cancellation log, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Wait for state to settle
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    // Player should NOT have been refunded (rolloverOnCancel=true keeps pot)
+    const pogAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const currencyAfterDraw = pogAfter.data.data[0]?.currency ?? 0;
+
+    assert.equal(
+      currencyAfterDraw,
+      currencyBeforeDraw,
+      `Expected player currency unchanged (no refund when rolloverOnCancel=true). Before: ${currencyBeforeDraw}, After: ${currencyAfterDraw}`,
+    );
+
+    // The currency-unchanged assertion above confirms rolloverOnCancel=true path executed correctly
+    // (no refund was given, so pot rolls over to next draw)
+  });
+});

--- a/modules/lottery/test/draw-lottery.test.ts
+++ b/modules/lottery/test/draw-lottery.test.ts
@@ -1,0 +1,269 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('lottery: draw-lottery cronjob', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let cronjobId: string;
+  let prefix: string;
+  let buyRoleId: string;
+  let buy2RoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 100,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: false,
+      },
+      // Set command cost=ticketPrice so the system auto-deducts 1x ticketPrice.
+      // The handler deducts only (amount-1)*ticketPrice additional.
+      systemConfig: {
+        commands: {
+          'buy-ticket': {
+            cost: 10,
+          },
+        },
+      },
+    });
+
+    const cronjob = mod.latestVersion.cronJobs[0];
+    if (!cronjob) throw new Error('Expected at least one cronjob in lottery module');
+    cronjobId = cronjob.id;
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Assign LOTTERY_BUY permission to player[0] and player[1]
+    buyRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY'],
+    );
+    buy2RoleId = await assignPermissions(
+      client,
+      ctx.players[1].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY'],
+    );
+
+    // Give both players currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[1].playerId,
+      { currency: 500 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, buyRoleId);
+    await cleanupRole(client, buy2RoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  async function triggerDraw(): Promise<{ success: boolean; logs: string[] }> {
+    const before = new Date();
+
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx.gameServer.id,
+      cronjobId,
+      moduleId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    const success = meta?.result?.success ?? false;
+    const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+
+    // Give Takaro time to fully commit variable updates before next operation reads them
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return { success, logs };
+  }
+
+  it('should cancel draw and refund exact ticket price when not enough participants', async () => {
+    // Only player[0] has bought a ticket — need 2 participants, have 1
+    const buyBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 1`,
+      playerId: ctx.players[0].playerId,
+    });
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buyBefore,
+      timeout: 30000,
+    });
+
+    // Record player[0]'s currency before the draw/refund
+    const pogBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const currencyBeforeRefund = pogBefore.data.data[0]?.currency ?? 0;
+
+    // Trigger the draw — should cancel since only 1 participant (need 2)
+    const { success, logs } = await triggerDraw();
+
+    assert.equal(success, true, `Expected draw cronjob to succeed (even on cancel), logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('cancelling draw')),
+      `Expected cancellation log, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Player should have been refunded exactly 10 (1 ticket * 10 price)
+    const pogAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const currencyAfterRefund = pogAfter.data.data[0]?.currency ?? 0;
+    assert.equal(
+      currencyAfterRefund,
+      currencyBeforeRefund + 10,
+      `Expected player currency to increase by exactly 10 (refund). Before: ${currencyBeforeRefund}, After: ${currencyAfterRefund}`,
+    );
+  });
+
+  it('should run draw and award winner exact prize when enough participants', async () => {
+    // Both player[0] and player[1] buy tickets
+    // player[0] buys 2 tickets, player[1] buys 1 ticket
+    // pot = 3 * 10 = 30, prize = floor(30 * 0.9) = 27
+    const buy0Before = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 2`,
+      playerId: ctx.players[0].playerId,
+    });
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buy0Before,
+      timeout: 30000,
+    });
+
+    const buy1Before = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 1`,
+      playerId: ctx.players[1].playerId,
+    });
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buy1Before,
+      timeout: 30000,
+    });
+
+    // Record currencies before draw
+    const pog0Before = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const pog1Before = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[1].playerId] },
+    });
+    const currency0Before = pog0Before.data.data[0]?.currency ?? 0;
+    const currency1Before = pog1Before.data.data[0]?.currency ?? 0;
+
+    // Trigger the draw
+    const { success, logs } = await triggerDraw();
+
+    assert.equal(success, true, `Expected draw to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('draw-lottery: winner=')),
+      `Expected winner selection log, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      logs.some((msg) => msg.includes('drawNumber=')),
+      `Expected drawNumber increment log, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Verify one of the players received exactly the expected prize
+    // pot = player[0] paid 2*10=20 (auto 10 + additional 10) + player[1] paid 1*10=10 (auto 10) = 30
+    // prize = floor(30 * 0.9) = 27
+    const expectedPrize = 27;
+
+    const pog0After = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[0].playerId] },
+    });
+    const pog1After = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [ctx.players[1].playerId] },
+    });
+    const currency0After = pog0After.data.data[0]?.currency ?? 0;
+    const currency1After = pog1After.data.data[0]?.currency ?? 0;
+
+    const player0Gain = currency0After - currency0Before;
+    const player1Gain = currency1After - currency1Before;
+
+    const player0Won = player0Gain === expectedPrize;
+    const player1Won = player1Gain === expectedPrize;
+
+    assert.ok(
+      player0Won || player1Won,
+      `Expected one player to receive exact prize of ${expectedPrize}. Player0 gain: ${player0Gain}, Player1 gain: ${player1Gain}`,
+    );
+    // Only one player should have won
+    assert.ok(
+      !(player0Won && player1Won),
+      `Expected only one winner, but both players gained ${expectedPrize}`,
+    );
+  });
+});
+

--- a/modules/lottery/test/lottery-info.test.ts
+++ b/modules/lottery/test/lottery-info.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('lottery: /lotteryinfo command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let buyRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 100,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Assign LOTTERY_BUY to player[0] for the ticket purchase test
+    buyRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY'],
+    );
+
+    // Give player[0] currency for purchases
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, buyRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show empty pot when no participants', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}lotteryinfo`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected lotteryinfo to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('lottery-info:') && msg.includes('participants=0')),
+      `Expected log to show participants=0, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show pot and participants after ticket purchases', async () => {
+    const player = ctx.players[0]!;
+
+    // First buy some tickets
+    const buyBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 3`,
+      playerId: player.playerId,
+    });
+
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buyBefore,
+      timeout: 30000,
+    });
+
+    // Now check lotteryinfo
+    const infoBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}lotteryinfo`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: infoBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected lotteryinfo to succeed after purchases');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    // After buying 3 tickets at price 10 each, pot should be 30
+    assert.ok(
+      logMessages.some((msg) => msg.includes('lottery-info:') && msg.includes('participants=1')),
+      `Expected log to show participants=1, got: ${JSON.stringify(logMessages)}`,
+    );
+    assert.ok(
+      logMessages.some((msg) => msg.includes('totalTickets=3')),
+      `Expected totalTickets=3 in log, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/lottery/test/next-draw.test.ts
+++ b/modules/lottery/test/next-draw.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('lottery: /nextdraw command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 100,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should return next draw time successfully', async () => {
+    const player = ctx.players[0]!;
+    const startTime = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}nextdraw`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: startTime,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(
+      meta?.result?.success,
+      true,
+      `Expected nextdraw to succeed, logs: ${JSON.stringify((meta?.result?.logs ?? []).map((l) => l.msg))}`,
+    );
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('nextdraw:')),
+      `Expected log to contain "nextdraw:" with hours and minutes, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/lottery/test/view-tickets.test.ts
+++ b/modules/lottery/test/view-tickets.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// Tests run sequentially with shared state:
+// player[0] has LOTTERY_BUY and LOTTERY_VIEW_TICKETS; player[1] has neither.
+// 1. Permission denied for player[1] (no LOTTERY_VIEW_TICKETS)
+// 2. Zero tickets for player[0] before any purchase
+// 3. Correct count (2) after purchase of 2 tickets
+
+describe('lottery: /viewtickets command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let permRoleId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy for currency operations
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        ticketPrice: 10,
+        profitMargin: 0.1,
+        maxTicketsPerPlayer: 100,
+        minimumParticipants: 2,
+        announceTicketPurchases: false,
+        rolloverOnCancel: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Assign both LOTTERY_BUY and LOTTERY_VIEW_TICKETS to player[0]
+    permRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['LOTTERY_BUY', 'LOTTERY_VIEW_TICKETS'],
+    );
+
+    // Give player[0] currency for purchases
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, permRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should deny viewtickets to player without LOTTERY_VIEW_TICKETS permission', async () => {
+    // player[1] has no LOTTERY_VIEW_TICKETS permission
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}viewtickets`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected viewtickets to fail for unpermitted player');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show zero tickets before any purchase', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}viewtickets`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected viewtickets to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('tickets=0')),
+      `Expected log to show tickets=0, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show correct ticket count after purchase', async () => {
+    const player = ctx.players[0]!;
+
+    // Buy 2 tickets first
+    const buyBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}buyticket 2`,
+      playerId: player.playerId,
+    });
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: buyBefore,
+      timeout: 30000,
+    });
+
+    // Now view tickets
+    const viewBefore = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}viewtickets`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: viewBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected viewtickets to succeed after purchase');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('tickets=2')),
+      `Expected log to show tickets=2, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a complete lottery module where players buy tickets with in-game currency and a daily cronjob draws a weighted random winner
- Supports configurable ticket price, profit margin, max tickets per player, minimum participants, and rollover-on-cancel
- Implements 4 commands (`buyticket`, `viewtickets`, `nextdraw`, `lotteryinfo`), 1 cronjob (`draw-lottery`), and 2 permissions (`LOTTERY_BUY`, `LOTTERY_VIEW_TICKETS`)

## Changes

- **Module metadata**: `module.json`, `config.json` (6 configurable fields), `permissions.json`
- **Commands**: Buy tickets with (N-1) cost model (command cost handles first ticket), view own tickets, check next draw time, view pot/participant info
- **Cronjob**: Daily draw with weighted random winner selection, prize = pot × (1 - profitMargin), minimum participant threshold, rollover or refund on cancellation with partial failure tracking
- **Helpers**: Shared variable CRUD, paginated ticket queries, resilient batch deletion via Promise.allSettled
- **Tests**: 6 test files (15 individual tests) covering buy-ticket, view-tickets, lottery-info, next-draw, draw-lottery, and draw-lottery-rollover

## Testing

- [x] All 15 tests pass individually via `npx tsx --test`
- [x] Build passes (`npm run build`, `npm run typecheck`)
- [x] Module pushes successfully (`scripts/module-push.sh`)
- [x] E2E verified on real Minecraft Paper server with bots:
  - Ticket purchasing with correct currency deduction (no double-charging)
  - Draw completion with prize award to winner
  - Permission enforcement
  - Rollover and refund paths

Closes gettakaro/community-modules-viewer#229