### PR TITLE
feat: add economyUtils module — currency, transfers, shop, kill rewards

### DIFF
--- a/modules/economy-utils/config.json
+++ b/modules/economy-utils/config.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "pendingAmount": {
+      "type": "number",
+      "description": "When a player transfers money, they must confirm the transfer when the amount is equal or above this value. Set to 0 to disable.",
+      "default": 0
+    },
+    "zombieKillReward": {
+      "type": "number",
+      "description": "The default amount of currency a player receives for killing an entity. This can be overridden by roles.",
+      "default": 1,
+      "minimum": 1
+    },
+    "transferTax": {
+      "type": "number",
+      "description": "Tax rate applied to player-to-player transfers. 0.05 means 5% tax. The tax amount vanishes from the economy. Set to 0 to disable.",
+      "default": 0,
+      "minimum": 0,
+      "maximum": 1
+    },
+    "maxTransferAmount": {
+      "type": "number",
+      "description": "Maximum amount a player can transfer in a single transaction. Set to 0 for unlimited.",
+      "default": 0,
+      "minimum": 0
+    },
+    "showBalanceOnLogin": {
+      "type": "boolean",
+      "description": "If true, players will receive a private message showing their balance when they connect to the server.",
+      "default": false
+    }
+  },
+  "required": [],
+  "additionalProperties": false
+}

--- a/modules/economy-utils/module.json
+++ b/modules/economy-utils/module.json
@@ -1,0 +1,6 @@
+{
+  "name": "test-economy-utils",
+  "description": "Currency management, player-to-player transfers, in-game shop browsing, and entity kill rewards.",
+  "version": "latest",
+  "supportedGames": ["all"]
+}

--- a/modules/economy-utils/permissions.json
+++ b/modules/economy-utils/permissions.json
@@ -1,0 +1,14 @@
+[
+  {
+    "permission": "ECONOMY_UTILS_MANAGE_CURRENCY",
+    "friendlyName": "Manage currency",
+    "description": "Allows players to manage currency of other players. This includes granting and revoking currency.",
+    "canHaveCount": false
+  },
+  {
+    "permission": "ZOMBIE_KILL_REWARD_OVERRIDE",
+    "friendlyName": "Zombie kill reward override",
+    "description": "Allows a role to override the amount of currency a player receives for killing an entity.",
+    "canHaveCount": true
+  }
+]

--- a/modules/economy-utils/src/commands/balance/command.json
+++ b/modules/economy-utils/src/commands/balance/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "balance",
+  "description": "Check your currency balance.",
+  "helpText": "Check your balance.",
+  "arguments": []
+}

--- a/modules/economy-utils/src/commands/balance/index.js
+++ b/modules/economy-utils/src/commands/balance/index.js
@@ -1,0 +1,10 @@
+import { takaro, data } from '@takaro/helpers';
+
+async function main() {
+  const { pog, gameServerId } = data;
+  const currencyName = (await takaro.settings.settingsControllerGetOne('currencyName', gameServerId)).data.data.value;
+  console.log(`balance: ${pog.currency} ${currencyName}`);
+  await pog.pm(`balance: ${pog.currency} ${currencyName}`);
+}
+
+await main();

--- a/modules/economy-utils/src/commands/claim/command.json
+++ b/modules/economy-utils/src/commands/claim/command.json
@@ -1,0 +1,14 @@
+{
+  "trigger": "claim",
+  "description": "Claim your pending shop orders.",
+  "helpText": "Claim your pending shop orders.",
+  "arguments": [
+    {
+      "name": "all",
+      "type": "boolean",
+      "helpText": "If true, claim ALL pending orders. If false, claim only the first one.",
+      "position": 0,
+      "defaultValue": "false"
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/claim/index.js
+++ b/modules/economy-utils/src/commands/claim/index.js
@@ -1,0 +1,64 @@
+import { takaro, data, TakaroUserError } from '@takaro/helpers';
+
+async function main() {
+  const { user, pog, arguments: args, gameServerId } = data;
+
+  if (!user) {
+    throw new TakaroUserError('You must link your account to Takaro to use this command.');
+  }
+
+  const filters = {
+    userId: [user.id],
+    status: ['PAID'],
+  };
+
+  if (gameServerId) {
+    filters.gameServerId = [gameServerId];
+  }
+
+  const pendingOrdersRes = await takaro.shopOrder.shopOrderControllerSearch({
+    filters,
+    sortBy: 'createdAt',
+    sortDirection: 'asc',
+  });
+
+  if (pendingOrdersRes.data.data.length === 0) {
+    console.log('You have no pending orders.');
+    await pog.pm('You have no pending orders.');
+    return;
+  }
+
+  let ordersToClaim = [];
+  if (args.all) {
+    ordersToClaim = pendingOrdersRes.data.data;
+  } else {
+    ordersToClaim.push(pendingOrdersRes.data.data[0]);
+  }
+
+  let claimed = 0;
+  let failed = 0;
+
+  for (const order of ordersToClaim) {
+    try {
+      await takaro.shopOrder.shopOrderControllerClaim(order.id);
+      claimed++;
+    } catch (err) {
+      console.error(`Failed to claim order ${order.id}: ${err}`);
+      failed++;
+    }
+  }
+
+  console.log(`claim: successfully claimed ${claimed} order(s)`);
+
+  if (claimed === 0) {
+    throw new TakaroUserError(`Failed to claim ${failed} order(s). Please try again later.`);
+  }
+
+  if (failed > 0) {
+    await pog.pm(`Claimed ${claimed} of ${ordersToClaim.length} orders. ${failed} failed.`);
+  } else {
+    await pog.pm(`Successfully claimed ${claimed} order(s).`);
+  }
+}
+
+await main();

--- a/modules/economy-utils/src/commands/confirmtransfer/command.json
+++ b/modules/economy-utils/src/commands/confirmtransfer/command.json
@@ -1,0 +1,6 @@
+{
+  "trigger": "confirmtransfer",
+  "description": "Confirms a pending transfer.",
+  "helpText": "Confirms a pending transfer.",
+  "arguments": []
+}

--- a/modules/economy-utils/src/commands/confirmtransfer/index.js
+++ b/modules/economy-utils/src/commands/confirmtransfer/index.js
@@ -1,0 +1,87 @@
+import { takaro, data, TakaroUserError } from '@takaro/helpers';
+import { executeTransfer, getVariable } from './economy-helpers.js';
+
+async function main() {
+  const { gameServerId, pog: sender, module: mod } = data;
+
+  const pendingVar = await getVariable(gameServerId, mod.moduleId, 'confirmTransfer', sender.playerId);
+
+  if (!pendingVar) {
+    throw new TakaroUserError('You have no pending transfer.');
+  }
+
+  const pendingTransfer = JSON.parse(pendingVar.value);
+
+  const FIVE_MINUTES_MS = 5 * 60 * 1000;
+  if (pendingTransfer.createdAt && Date.now() - pendingTransfer.createdAt > FIVE_MINUTES_MS) {
+    await takaro.variable.variableControllerDelete(pendingVar.id);
+    throw new TakaroUserError('Your pending transfer has expired. Please initiate a new transfer.');
+  }
+
+  const amount = pendingTransfer.amount;
+
+  const currencyName = await takaro.settings
+    .settingsControllerGetOne('currencyName', gameServerId)
+    .then((r) => r.data.data.value);
+
+  if (mod.userConfig.maxTransferAmount > 0 && amount > mod.userConfig.maxTransferAmount) {
+    await takaro.variable.variableControllerDelete(pendingVar.id);
+    throw new TakaroUserError(
+      `This transfer of ${amount} ${currencyName} exceeds the current maximum transfer limit of ${mod.userConfig.maxTransferAmount} ${currencyName}. Transfer cancelled.`,
+    );
+  }
+
+  let freshReceiver;
+  try {
+    freshReceiver = (
+      await takaro.playerOnGameserver.playerOnGameServerControllerGetOne(
+        gameServerId,
+        pendingTransfer.receiver.playerId,
+      )
+    ).data.data;
+  } catch {
+    await takaro.variable.variableControllerDelete(pendingVar.id);
+    throw new TakaroUserError('The receiver is no longer available on this server.');
+  }
+
+  const [receiverName, senderName] = await Promise.all([
+    takaro.player.playerControllerGetOne(pendingTransfer.receiver.playerId).then((r) => r.data.data.name),
+    takaro.player.playerControllerGetOne(sender.playerId).then((r) => r.data.data.name),
+  ]);
+
+  const tax = mod.userConfig.transferTax || 0;
+  // Tax shown here for UX; executeTransfer recalculates internally for consistency
+  const taxAmount = tax > 0 ? Math.ceil(amount * tax) : 0;
+  const receiverAmount = amount - taxAmount;
+
+  await sender.pm(
+    `Confirming transfer of ${amount} ${currencyName} to ${receiverName}. Tax: ${taxAmount} ${currencyName} (${(tax * 100).toFixed(0)}%). Receiver gets: ${receiverAmount} ${currencyName}.`,
+  );
+
+  try {
+    await executeTransfer(
+      gameServerId,
+      mod.moduleId,
+      sender,
+      freshReceiver,
+      amount,
+      tax,
+      currencyName,
+      senderName,
+      receiverName,
+    );
+  } catch (err) {
+    if (err instanceof TakaroUserError) {
+      // Non-transient error — clean up the pending transfer so the player doesn't retry a doomed operation
+      try {
+        await takaro.variable.variableControllerDelete(pendingVar.id);
+      } catch {}
+    }
+    throw err;
+  }
+
+  // On success, delete the pending variable
+  await takaro.variable.variableControllerDelete(pendingVar.id);
+}
+
+await main();

--- a/modules/economy-utils/src/commands/grantcurrency/command.json
+++ b/modules/economy-utils/src/commands/grantcurrency/command.json
@@ -1,0 +1,19 @@
+{
+  "trigger": "grantcurrency",
+  "description": "Grant money to a player.",
+  "helpText": "Grant money to a player. The money is not taken from your own balance but is new currency.",
+  "arguments": [
+    {
+      "name": "receiver",
+      "type": "player",
+      "helpText": "The player to grant currency to.",
+      "position": 0
+    },
+    {
+      "name": "amount",
+      "type": "number",
+      "helpText": "The amount of money.",
+      "position": 1
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/grantcurrency/index.js
+++ b/modules/economy-utils/src/commands/grantcurrency/index.js
@@ -1,0 +1,54 @@
+import { takaro, data, TakaroUserError, checkPermission } from '@takaro/helpers';
+
+async function main() {
+  const { pog: granter, arguments: args, gameServerId } = data;
+
+  if (!checkPermission(granter, 'ECONOMY_UTILS_MANAGE_CURRENCY')) {
+    throw new TakaroUserError('You do not have permission to manage currency.');
+  }
+
+  const receiver = args.receiver;
+  const amount = args.amount;
+
+  if (!receiver) throw new TakaroUserError('You must specify a player.');
+
+  if (!Number.isInteger(amount) || amount < 1) {
+    throw new TakaroUserError('Amount must be a positive whole number.');
+  }
+
+  const [currencyName, granterName, receiverName] = await Promise.all([
+    takaro.settings.settingsControllerGetOne('currencyName', gameServerId).then((r) => r.data.data.value),
+    takaro.player.playerControllerGetOne(granter.playerId).then((r) => r.data.data.name),
+    takaro.player.playerControllerGetOne(receiver.playerId).then((r) => r.data.data.name),
+  ]);
+
+  try {
+    await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, receiver.playerId, {
+      currency: amount,
+    });
+  } catch {
+    throw new TakaroUserError('Failed to grant currency. Please check the player exists on this server.');
+  }
+
+  console.log(`grantcurrency: successfully added ${amount} to ${receiverName}`);
+
+  // Currency operation already succeeded — don't let notification failures propagate
+  try {
+    const messageToReceiver = takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `Granted ${amount} ${currencyName} by ${granterName}`,
+      opts: {
+        recipient: {
+          gameId: receiver.gameId,
+        },
+      },
+    });
+    await Promise.all([
+      granter.pm(`You successfully granted ${amount} ${currencyName} to ${receiverName}`),
+      messageToReceiver,
+    ]);
+  } catch (notifyErr) {
+    console.error(`grantcurrency: currency granted but notification failed: ${notifyErr}`);
+  }
+}
+
+await main();

--- a/modules/economy-utils/src/commands/revokecurrency/command.json
+++ b/modules/economy-utils/src/commands/revokecurrency/command.json
@@ -1,0 +1,19 @@
+{
+  "trigger": "revokecurrency",
+  "description": "Revoke money from a player.",
+  "helpText": "Revokes money from a player. The money disappears.",
+  "arguments": [
+    {
+      "name": "receiver",
+      "type": "player",
+      "helpText": "The player to revoke currency from.",
+      "position": 0
+    },
+    {
+      "name": "amount",
+      "type": "number",
+      "helpText": "The amount of money.",
+      "position": 1
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/revokecurrency/index.js
+++ b/modules/economy-utils/src/commands/revokecurrency/index.js
@@ -1,0 +1,56 @@
+import { takaro, data, TakaroUserError, checkPermission } from '@takaro/helpers';
+
+async function main() {
+  const { pog: revoker, arguments: args, gameServerId } = data;
+
+  if (!checkPermission(revoker, 'ECONOMY_UTILS_MANAGE_CURRENCY')) {
+    throw new TakaroUserError('You do not have permission to manage currency.');
+  }
+
+  const receiver = args.receiver;
+  const amount = args.amount;
+
+  if (!receiver) throw new TakaroUserError('You must specify a player.');
+
+  if (!Number.isInteger(amount) || amount < 1) {
+    throw new TakaroUserError('Amount must be a positive whole number.');
+  }
+
+  const [currencyName, revokerName, receiverName] = await Promise.all([
+    takaro.settings.settingsControllerGetOne('currencyName', gameServerId).then((r) => r.data.data.value),
+    takaro.player.playerControllerGetOne(revoker.playerId).then((r) => r.data.data.name),
+    takaro.player.playerControllerGetOne(receiver.playerId).then((r) => r.data.data.name),
+  ]);
+
+  try {
+    await takaro.playerOnGameserver.playerOnGameServerControllerDeductCurrency(gameServerId, receiver.playerId, {
+      currency: amount,
+    });
+  } catch {
+    throw new TakaroUserError(
+      `Failed to revoke ${amount} ${currencyName} from ${receiverName}. They may not have enough balance.`,
+    );
+  }
+
+  console.log(`revokecurrency: successfully deducted ${amount} from ${receiverName}`);
+
+  // Currency operation already succeeded — don't let notification failures propagate
+  try {
+    const messageToReceiver = takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `${amount} ${currencyName} were revoked by ${revokerName}`,
+      opts: {
+        recipient: {
+          gameId: receiver.gameId,
+        },
+      },
+    });
+    await Promise.all([
+      revoker.pm(`You successfully revoked ${amount} ${currencyName} of ${receiverName}'s balance`),
+      messageToReceiver,
+    ]);
+  } catch (notifyErr) {
+    console.error(`revokecurrency: currency revoked but notification failed: ${notifyErr}`);
+  }
+}
+
+await main();

--- a/modules/economy-utils/src/commands/shop/command.json
+++ b/modules/economy-utils/src/commands/shop/command.json
@@ -1,0 +1,28 @@
+{
+  "trigger": "shop",
+  "description": "Browse the shop and view available items.",
+  "helpText": "Browse the shop and view available items.",
+  "arguments": [
+    {
+      "name": "page",
+      "type": "number",
+      "helpText": "Display more items from the shop by specifying a page number.",
+      "position": 0,
+      "defaultValue": "1"
+    },
+    {
+      "name": "item",
+      "type": "number",
+      "helpText": "Select a specific item to view more details.",
+      "position": 1,
+      "defaultValue": "0"
+    },
+    {
+      "name": "action",
+      "type": "string",
+      "helpText": "Perform an action on the selected item. Currently only \"buy\" is supported.",
+      "position": 2,
+      "defaultValue": "none"
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/shop/index.js
+++ b/modules/economy-utils/src/commands/shop/index.js
@@ -1,0 +1,87 @@
+import { takaro, data, TakaroUserError } from '@takaro/helpers';
+
+async function main() {
+  const { arguments: args, pog, gameServerId } = data;
+  let { page, item, action } = args;
+
+  if (!page || page < 1) page = 1;
+  page = Math.floor(page);
+
+  const shopItems = await takaro.shopListing.shopListingControllerSearch({
+    limit: 5,
+    page: page - 1,
+    sortBy: 'name',
+    sortDirection: 'asc',
+    filters: {
+      gameServerId: [gameServerId],
+      draft: false,
+    },
+  });
+
+  if (shopItems.data.data.length === 0) {
+    console.log('No items found.');
+    await pog.pm('No items found.');
+    return;
+  }
+
+  const currencyName = (await takaro.settings.settingsControllerGetOne('currencyName', gameServerId)).data.data.value;
+
+  if (!item) {
+    let index = 1;
+    for (const listing of shopItems.data.data) {
+      const items = listing.items.slice(0, 3).map((i) => {
+        return `${i.amount}x ${i.item.name}`;
+      });
+      await pog.pm(`${index} - ${listing.name} - ${listing.price} ${currencyName}. ${items.join(', ')}`);
+      index++;
+    }
+    return;
+  }
+
+  const selectedItem = shopItems.data.data[item - 1];
+  if (!selectedItem) {
+    throw new TakaroUserError(
+      `Item not found. Please select an item from the list, valid options are 1-${shopItems.data.data.length}.`,
+    );
+  }
+
+  if (action === 'none') {
+    await pog.pm(`Listing ${selectedItem.name} - ${selectedItem.price} ${currencyName}`);
+    await Promise.all(
+      selectedItem.items.map((i) => {
+        const quality = i.quality ? `Quality: ${i.quality}` : '';
+        const description = (i.item.description ? `Description: ${i.item.description}` : '').replaceAll('\\n', ' ');
+        return pog.pm(`- ${i.amount}x ${i.item.name}. ${quality} ${description}`);
+      }),
+    );
+    return;
+  }
+
+  if (action === 'buy') {
+    // Pre-check is UX-only; server-side order creation also validates balance.
+    if (pog.currency < selectedItem.price) {
+      throw new TakaroUserError('You cannot afford this item.');
+    }
+
+    const orderRes = await takaro.shopOrder.shopOrderControllerCreate({
+      amount: 1,
+      listingId: selectedItem.id,
+      playerId: pog.playerId,
+    });
+
+    // Attempt to claim the order; if claim fails, inform the player to use /claim
+    try {
+      await takaro.shopOrder.shopOrderControllerClaim(orderRes.data.data.id);
+      await pog.pm(`You have purchased ${selectedItem.name} for ${selectedItem.price} ${currencyName}.`);
+    } catch {
+      await pog.pm(
+        `Purchase complete but delivery failed — use /claim to retry.`,
+      );
+    }
+    return;
+  }
+
+  throw new TakaroUserError('Invalid action. Valid actions are "buy".');
+}
+
+await main();

--- a/modules/economy-utils/src/commands/topcurrency/command.json
+++ b/modules/economy-utils/src/commands/topcurrency/command.json
@@ -1,0 +1,14 @@
+{
+  "trigger": "topcurrency",
+  "description": "List the players with the highest balance.",
+  "helpText": "List of the top players with the highest balance.",
+  "arguments": [
+    {
+      "name": "count",
+      "type": "number",
+      "helpText": "Number of players to display (default 10, max 25).",
+      "position": 0,
+      "defaultValue": "10"
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/topcurrency/index.js
+++ b/modules/economy-utils/src/commands/topcurrency/index.js
@@ -1,0 +1,40 @@
+import { takaro, data } from '@takaro/helpers';
+
+async function main() {
+  const { arguments: args, pog, gameServerId } = data;
+
+  const count = Math.min(Math.max(1, Math.floor(args.count || 10)), 25);
+
+  const richest = (
+    await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [gameServerId] },
+      limit: count,
+      sortBy: 'currency',
+      sortDirection: 'desc',
+      extend: ['player'],
+    })
+  ).data.data;
+
+  if (richest.length === 0) {
+    await pog.pm('No players found.');
+    return;
+  }
+
+  const currencyName = (await takaro.settings.settingsControllerGetOne('currencyName', gameServerId)).data.data.value;
+
+  // Fetch all player names in parallel (order doesn't matter for name lookups)
+  const playerNames = await Promise.all(
+    richest.map((p) => takaro.player.playerControllerGetOne(p.playerId).then((r) => r.data.data.name)),
+  );
+
+  console.log('Richest players:');
+  await pog.pm('Richest players:');
+  // Send PMs sequentially to preserve leaderboard order
+  for (let i = 0; i < richest.length; i++) {
+    const line = `${i + 1}. ${playerNames[i]} - ${richest[i].currency} ${currencyName}`;
+    console.log(line);
+    await pog.pm(line);
+  }
+}
+
+await main();

--- a/modules/economy-utils/src/commands/transfer/command.json
+++ b/modules/economy-utils/src/commands/transfer/command.json
@@ -1,0 +1,19 @@
+{
+  "trigger": "transfer",
+  "description": "Transfer money to another player.",
+  "helpText": "Transfer money to another player.",
+  "arguments": [
+    {
+      "name": "receiver",
+      "type": "player",
+      "helpText": "The player to transfer money to.",
+      "position": 0
+    },
+    {
+      "name": "amount",
+      "type": "number",
+      "helpText": "The amount of money to transfer.",
+      "position": 1
+    }
+  ]
+}

--- a/modules/economy-utils/src/commands/transfer/index.js
+++ b/modules/economy-utils/src/commands/transfer/index.js
@@ -1,0 +1,74 @@
+import { takaro, data, TakaroUserError } from '@takaro/helpers';
+import { executeTransfer, getVariable, setVariable } from './economy-helpers.js';
+
+async function main() {
+  const { pog: sender, arguments: args, gameServerId, module: mod } = data;
+
+  const currencyName = (await takaro.settings.settingsControllerGetOne('currencyName', gameServerId)).data.data.value;
+  const prefix = (await takaro.settings.settingsControllerGetOne('commandPrefix', gameServerId)).data.data.value;
+
+  const receiver = args.receiver;
+  const amount = args.amount;
+
+  // Guard: receiver must be specified
+  if (!receiver) throw new TakaroUserError('You must specify a player to transfer to.');
+
+  // Validate amount is a positive integer
+  if (!Number.isInteger(amount) || amount < 1) {
+    throw new TakaroUserError('Transfer amount must be a positive whole number.');
+  }
+
+  // Prevent self-transfer
+  if (sender.playerId === receiver.playerId) {
+    throw new TakaroUserError('You cannot transfer currency to yourself.');
+  }
+
+  // Check max transfer limit
+  if (mod.userConfig.maxTransferAmount > 0 && amount > mod.userConfig.maxTransferAmount) {
+    throw new TakaroUserError(
+      `You cannot transfer more than ${mod.userConfig.maxTransferAmount} ${currencyName} at once.`,
+    );
+  }
+
+  const [senderName, receiverName] = await Promise.all([
+    takaro.player.playerControllerGetOne(sender.playerId).then((r) => r.data.data.name),
+    takaro.player.playerControllerGetOne(receiver.playerId).then((r) => r.data.data.name),
+  ]);
+
+  // Check if confirmation is required
+  if (mod.userConfig.pendingAmount !== 0 && amount >= mod.userConfig.pendingAmount) {
+    // Delete any existing pending transfer for this player before creating a new one
+    const existingVar = await getVariable(gameServerId, mod.moduleId, 'confirmTransfer', sender.playerId);
+    if (existingVar) {
+      await takaro.variable.variableControllerDelete(existingVar.id);
+    }
+
+    await setVariable(
+      gameServerId,
+      mod.moduleId,
+      'confirmTransfer',
+      {
+        amount,
+        createdAt: Date.now(),
+        receiver: {
+          id: receiver.id,
+          gameId: receiver.gameId,
+          playerId: receiver.playerId,
+        },
+      },
+      sender.playerId,
+    );
+
+    console.log(`Pending transfer: ${amount} to ${receiverName}. Awaiting confirmtransfer.`);
+    await sender.pm(
+      `You are about to send ${amount} ${currencyName} to ${receiverName}. (Please confirm by typing ${prefix}confirmtransfer)`,
+    );
+    return;
+  }
+
+  const tax = mod.userConfig.transferTax || 0;
+
+  await executeTransfer(gameServerId, mod.moduleId, sender, receiver, amount, tax, currencyName, senderName, receiverName);
+}
+
+await main();

--- a/modules/economy-utils/src/cronjobs/zombie-kill-reward/cronjob.json
+++ b/modules/economy-utils/src/cronjobs/zombie-kill-reward/cronjob.json
@@ -1,0 +1,4 @@
+{
+  "temporalValue": "*/5 * * * *",
+  "description": "Awards currency to players for entity kills since the last run."
+}

--- a/modules/economy-utils/src/cronjobs/zombie-kill-reward/index.js
+++ b/modules/economy-utils/src/cronjobs/zombie-kill-reward/index.js
@@ -1,0 +1,87 @@
+import { data, takaro, checkPermission } from '@takaro/helpers';
+import { getVariable, setVariable } from './economy-helpers.js';
+
+const VARIABLE_KEY = 'lastZombieKillReward';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+
+  const rewardPerKill = mod.userConfig.zombieKillReward;
+
+  // Guard: non-positive reward is a misconfiguration — skip silently
+  if (rewardPerKill <= 0) return;
+
+  const lastRunVar = await getVariable(gameServerId, mod.moduleId, VARIABLE_KEY);
+
+  // We last ran the rewards script at this time
+  // If this is the first time we run it, just get the last 5 minutes
+  const lastRun = lastRunVar
+    ? new Date(JSON.parse(lastRunVar.value))
+    : new Date(Date.now() - 5 * 60 * 1000);
+
+  // Fetch all the kill events since the last time we gave out rewards
+  const killEvents = (
+    await takaro.event.eventControllerSearch({
+      filters: { eventName: ['entity-killed'], gameserverId: [gameServerId] },
+      greaterThan: { createdAt: lastRun.toISOString() },
+      limit: 1000,
+    })
+  ).data.data;
+
+  console.log(`Found ${killEvents.length} kill events since ${lastRun.toISOString()}`);
+
+  if (killEvents.length >= 1000) {
+    console.log('Warning: event limit reached, some kills may not be rewarded');
+  }
+
+  // Group the events by player
+  const playerKills = {};
+  for (const killEvent of killEvents) {
+    if (!playerKills[killEvent.playerId]) {
+      playerKills[killEvent.playerId] = [];
+    }
+    playerKills[killEvent.playerId].push(killEvent);
+  }
+
+  const playerEntries = Object.entries(playerKills);
+
+  // Give each player their reward using allSettled so partial failures don't block others
+  const results = await Promise.allSettled(
+    playerEntries.map(async ([playerId, kills]) => {
+      const pog = (
+        await takaro.playerOnGameserver.playerOnGameServerControllerGetOne(gameServerId, playerId)
+      ).data.data;
+      const hasPermission = checkPermission(pog, 'ZOMBIE_KILL_REWARD_OVERRIDE');
+      const defaultReward = rewardPerKill;
+
+      // count=0 means admin intentionally disabled rewards for this player
+      if (hasPermission && hasPermission.count === 0) {
+        console.log(`Skipping reward for player ${playerId}: ZOMBIE_KILL_REWARD_OVERRIDE count=0`);
+        return;
+      }
+
+      const reward = hasPermission && hasPermission.count != null ? hasPermission.count : defaultReward;
+      const totalReward = reward * kills.length;
+      return takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, playerId, {
+        currency: totalReward,
+      });
+    }),
+  );
+
+  // Update timestamp UNCONDITIONALLY — prevents duplicate payouts which is worse than skipping failed ones
+  await setVariable(gameServerId, mod.moduleId, VARIABLE_KEY, new Date());
+
+  const failures = results.filter((r) => r.status === 'rejected');
+  if (failures.length > 0) {
+    playerEntries.forEach(([playerId], index) => {
+      if (results[index].status === 'rejected') {
+        console.error(`Failed to reward player ${playerId}: ${results[index].reason}`);
+      }
+    });
+  }
+
+  const successes = results.filter((r) => r.status === 'fulfilled').length;
+  console.log(`Successfully rewarded ${successes} player(s), ${failures.length} failed`);
+}
+
+await main();

--- a/modules/economy-utils/src/functions/economy-helpers.js
+++ b/modules/economy-utils/src/functions/economy-helpers.js
@@ -1,0 +1,170 @@
+import { takaro, TakaroUserError } from '@takaro/helpers';
+
+/**
+ * Generic variable read helper. Returns the variable record or null if not found.
+ * Pass playerId to scope the variable to a specific player.
+ */
+export async function getVariable(gameServerId, moduleId, key, playerId) {
+  const filters = {
+    key: [key],
+    gameServerId: [gameServerId],
+    moduleId: [moduleId],
+  };
+  if (playerId) filters.playerId = [playerId];
+  const res = await takaro.variable.variableControllerSearch({ filters });
+  return res.data.data.length > 0 ? res.data.data[0] : null;
+}
+
+/**
+ * Generic variable write helper. Creates if not existing, updates if existing.
+ * Pass playerId to scope the variable to a specific player.
+ */
+export async function setVariable(gameServerId, moduleId, key, value, playerId) {
+  const existing = await getVariable(gameServerId, moduleId, key, playerId);
+  const serialized = JSON.stringify(value);
+  if (existing) {
+    await takaro.variable.variableControllerUpdate(existing.id, { value: serialized });
+  } else {
+    const createPayload = {
+      key,
+      value: serialized,
+      gameServerId,
+      moduleId,
+    };
+    if (playerId) createPayload.playerId = playerId;
+    await takaro.variable.variableControllerCreate(createPayload);
+  }
+}
+
+export async function executeTransfer(
+  gameServerId,
+  moduleId,
+  senderPog,
+  receiver,
+  amount,
+  transferTax,
+  currencyName,
+  senderName,
+  receiverName,
+) {
+  if (!receiver || !receiver.id || !receiver.playerId || !receiver.gameId)
+    throw new TakaroUserError('Invalid receiver data.');
+
+  // Note: DeductCurrency/AddCurrency use playerId; TransactBetweenPlayers uses pog.id (playerOnGameServer ID)
+  if (transferTax > 0) {
+    // Use Math.ceil so even small transfers pay at least 1 tax when tax > 0
+    const taxAmount = Math.ceil(amount * transferTax);
+    const receiverAmount = amount - taxAmount;
+
+    // Guard: tax rate 1.0 (or rounding) would send zero to receiver
+    if (receiverAmount <= 0) {
+      throw new TakaroUserError(
+        'Transfer tax would consume the entire amount. No currency would reach the receiver.',
+      );
+    }
+
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerDeductCurrency(gameServerId, senderPog.playerId, {
+        currency: amount,
+      });
+    } catch {
+      throw new TakaroUserError('Insufficient balance to complete this transfer.');
+    }
+
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, receiver.playerId, {
+        currency: receiverAmount,
+      });
+    } catch (err) {
+      // Refund sender since we already deducted from them
+      try {
+        await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, senderPog.playerId, {
+          currency: amount,
+        });
+      } catch (refundErr) {
+        console.error(`Failed to refund sender after failed transfer: ${refundErr}`);
+        // Persist a record of the failed refund so admins can investigate and manually correct it
+        const failedRefundKey = `failed-refund-${senderPog.playerId}-${Date.now()}`;
+        try {
+          await takaro.variable.variableControllerCreate({
+            key: failedRefundKey,
+            value: JSON.stringify({
+              player: senderPog.playerId,
+              amount,
+              timestamp: new Date().toISOString(),
+              error: String(refundErr),
+            }),
+            gameServerId,
+            moduleId,
+          });
+        } catch (persistErr) {
+          console.error(`Failed to persist refund audit record: ${persistErr}`);
+        }
+      }
+      // Honest message: refund was attempted but may not have succeeded
+      throw new TakaroUserError(
+        'Transfer failed. A refund was attempted but may not have succeeded. Please check your balance.',
+      );
+    }
+
+    console.log(
+      `Transfer with tax: successfully transferred ${amount} ${currencyName} to ${receiverName} (${taxAmount} ${currencyName} tax, ${receiverAmount} ${currencyName} received)`,
+    );
+
+    // Notifications — wrap so a failed PM doesn't undo the already-completed transfer
+    try {
+      const messageToReceiver = takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `You received ${receiverAmount} ${currencyName} from ${senderName} (${taxAmount} ${currencyName} tax applied)`,
+        opts: {
+          recipient: {
+            gameId: receiver.gameId,
+          },
+        },
+      });
+      await Promise.all([
+        senderPog.pm(
+          `You successfully transferred ${amount} ${currencyName} to ${receiverName} (${taxAmount} ${currencyName} tax, ${receiverAmount} ${currencyName} received)`,
+        ),
+        messageToReceiver,
+      ]);
+    } catch (notifyErr) {
+      console.error(`Transfer succeeded but notification failed: ${notifyErr}`);
+    }
+  } else {
+    // No tax: use atomic TransactBetweenPlayers
+    try {
+      await takaro.playerOnGameserver.playerOnGameServerControllerTransactBetweenPlayers(
+        senderPog.gameServerId,
+        senderPog.id,
+        receiver.id,
+        {
+          currency: amount,
+        },
+      );
+    } catch {
+      throw new TakaroUserError(
+        `Failed to transfer ${amount} ${currencyName} to ${receiverName}. Are you sure you have enough balance?`,
+      );
+    }
+
+    console.log(`Transfer: successfully transferred ${amount} ${currencyName} to ${receiverName}`);
+
+    // Notifications — wrap so a failed PM doesn't undo the already-completed transfer
+    try {
+      const messageToReceiver = takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `You received ${amount} ${currencyName} from ${senderName}`,
+        opts: {
+          recipient: {
+            gameId: receiver.gameId,
+          },
+        },
+      });
+      await Promise.all([
+        senderPog.pm(`You successfully transferred ${amount} ${currencyName} to ${receiverName}`),
+        messageToReceiver,
+      ]);
+    } catch (notifyErr) {
+      console.error(`Transfer succeeded but notification failed: ${notifyErr}`);
+    }
+  }
+}

--- a/modules/economy-utils/src/hooks/on-login-balance/hook.json
+++ b/modules/economy-utils/src/hooks/on-login-balance/hook.json
@@ -1,0 +1,4 @@
+{
+  "eventType": "player-connected",
+  "description": "Shows the player their balance when they connect to the server."
+}

--- a/modules/economy-utils/src/hooks/on-login-balance/index.js
+++ b/modules/economy-utils/src/hooks/on-login-balance/index.js
@@ -1,0 +1,16 @@
+import { takaro, data } from '@takaro/helpers';
+
+async function main() {
+  const { gameServerId, player, pog, module: mod } = data;
+
+  if (!mod.userConfig.showBalanceOnLogin) {
+    return;
+  }
+
+  const currencyName = (await takaro.settings.settingsControllerGetOne('currencyName', gameServerId)).data.data.value;
+
+  console.log(`on-login-balance: player has ${pog.currency} ${currencyName}`);
+  await pog.pm(`Your balance: ${pog.currency} ${currencyName}`);
+}
+
+await main();

--- a/modules/economy-utils/test/admin-currency.test.ts
+++ b/modules/economy-utils/test/admin-currency.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// player[0] has ECONOMY_UTILS_MANAGE_CURRENCY permission; player[1] does NOT
+
+describe('economy-utils: /grantcurrency and /revokecurrency commands', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let manageRoleId: string;
+  let player0Name: string;
+  let player1Name: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    manageRoleId = await assignPermissions(
+      client,
+      ctx.players[0].playerId,
+      ctx.gameServer.id,
+      ['ECONOMY_UTILS_MANAGE_CURRENCY'],
+    );
+
+    // Look up player names for use in command messages
+    const [p0data, p1data] = await Promise.all([
+      client.player.playerControllerGetOne(ctx.players[0].playerId),
+      client.player.playerControllerGetOne(ctx.players[1].playerId),
+    ]);
+    player0Name = p0data.data.data.name;
+    player1Name = p1data.data.data.name;
+  });
+
+  after(async () => {
+    await cleanupRole(client, manageRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should grant currency to a player with permission', async () => {
+    const granter = ctx.players[0]!;
+    const target = ctx.players[1]!;
+
+    // Check balance before grant
+    const balanceBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [target.playerId] },
+    }).then((r) => r.data.data[0]?.currency ?? 0);
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}grantcurrency ${player1Name} 200`,
+      playerId: granter.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected grantcurrency to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('successfully added')),
+      `Expected "successfully added" in log, got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify balance increased by exactly 200
+    const balanceAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [target.playerId] },
+    }).then((r) => r.data.data[0]?.currency ?? 0);
+    assert.equal(balanceAfter, balanceBefore + 200, `Balance should increase by 200. Before: ${balanceBefore}, After: ${balanceAfter}`);
+  });
+
+  it('should deny grantcurrency to player without permission', async () => {
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}grantcurrency ${player0Name} 100`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected grantcurrency to fail without permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should revoke currency from a player with permission', async () => {
+    const revoker = ctx.players[0]!;
+    const target = ctx.players[1]!;
+    // player[1] has currency from the grant test
+
+    // Check balance before revoke
+    const balanceBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [target.playerId] },
+    }).then((r) => r.data.data[0]?.currency ?? 0);
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}revokecurrency ${player1Name} 50`,
+      playerId: revoker.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected revokecurrency to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('successfully deducted')),
+      `Expected "successfully deducted" in log, got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify balance decreased by exactly 50
+    const balanceAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [target.playerId] },
+    }).then((r) => r.data.data[0]?.currency ?? 0);
+    assert.equal(balanceAfter, balanceBefore - 50, `Balance should decrease by 50. Before: ${balanceBefore}, After: ${balanceAfter}`);
+  });
+
+  it('should deny revokecurrency to player without permission', async () => {
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}revokecurrency ${player0Name} 10`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected revokecurrency to fail without permission');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/balance.test.ts
+++ b/modules/economy-utils/test/balance.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /balance command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy for this game server
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show player balance of 0 by default', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}balance`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected balance command to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('balance:')),
+      `Expected log to contain "balance:", got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show updated balance after receiving currency', async () => {
+    const player = ctx.players[0]!;
+
+    // Give player some currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(ctx.gameServer.id, player.playerId, {
+      currency: 250,
+    });
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}balance`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected balance command to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('balance:') && msg.includes('250')),
+      `Expected log to show balance of 250, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/claim.test.ts
+++ b/modules/economy-utils/test/claim.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /claim command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should report no pending orders when none exist', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}claim`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+
+    // In the mock server, players are not linked to Takaro user accounts.
+    // The claim command checks for a linked user first and throws TakaroUserError if not found.
+    // So success===false and "link your account" is the expected outcome in this test environment.
+    assert.equal(meta?.result?.success, false, 'Expected claim to fail due to no linked user account in mock server');
+    assert.ok(
+      logMessages.some((msg) => msg.includes('link your account')),
+      `Expected "link your account" error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/on-login-balance.test.ts
+++ b/modules/economy-utils/test/on-login-balance.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: on-login-balance hook', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with showBalanceOnLogin: true to enable the hook behavior
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: true,
+      },
+    });
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should fire hook-executed when a player connects with showBalanceOnLogin: true', async () => {
+    // Disconnect all players, then reconnect to trigger the hook
+    await ctx.server.executeConsoleCommand('disconnectAll');
+
+    // Wait for disconnect events to settle before setting our timestamp baseline
+    const disconnectSettleMs = Number(process.env['TEST_DISCONNECT_SETTLE_MS'] ?? 2000);
+    await new Promise((resolve) => setTimeout(resolve, disconnectSettleMs));
+
+    const before = new Date();
+
+    // Connect all players — triggers player-connected events which fires the hook
+    await ctx.server.executeConsoleCommand('connectAll');
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.HookExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a hook-executed event');
+    assert.equal(event.eventName, 'hook-executed', 'Event name should be hook-executed');
+    assert.equal(event.gameserverId, ctx.gameServer.id, 'Event should be for the correct game server');
+    assert.ok(event.moduleId, 'Event should reference the installed module');
+
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected hook to succeed');
+
+    // Verify log message contains both 'on-login-balance' and 'balance' (confirming the balance PM was prepared)
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('on-login-balance') && msg.toLowerCase().includes('balance')),
+      `Expected on-login-balance log with balance info, got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Note: showBalanceOnLogin: false is implicitly tested by all other test files — they install
+    // the module with showBalanceOnLogin: false and no hook-executed events are expected.
+  });
+});

--- a/modules/economy-utils/test/shop.test.ts
+++ b/modules/economy-utils/test/shop.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /shop command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show shop listing when called without arguments', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}shop`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected shop to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('No items found')),
+      `Expected shop listing (empty), got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should show no items when shop is empty', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    // Use page 2 to bypass the "no arguments" usage check (page=1,item=0,action='none')
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}shop 2`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected shop to succeed even with no items');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('No items found')),
+      `Expected "No items found" message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should handle arguments gracefully when shop is empty', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    // With an empty shop, any page/item/action combination hits "No items found" first
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}shop 1 1 invalid`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    // Empty shop returns early with "No items found" — success path
+    assert.equal(meta?.result?.success, true, 'Expected success since shop is empty (returns "No items found")');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('No items found')),
+      `Expected "No items found" message, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/topcurrency.test.ts
+++ b/modules/economy-utils/test/topcurrency.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /topcurrency command', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give players different amounts of currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 300 },
+    );
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[1].playerId,
+      { currency: 100 },
+    );
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should show leaderboard of richest players', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}topcurrency`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected topcurrency to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('Richest players:')),
+      `Expected "Richest players:" header, got: ${JSON.stringify(logMessages)}`,
+    );
+    // player[0] has 300, should be ranked 1st
+    assert.ok(
+      logMessages.some((msg) => msg.includes('1.') && msg.includes('300')),
+      `Expected player[0] ranked #1 with 300 currency, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should respect custom count argument', async () => {
+    const player = ctx.players[0]!;
+    const before = new Date();
+
+    // Request only top 1
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}topcurrency 1`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected topcurrency with count=1 to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    // Should have "1." but NOT "2."
+    assert.ok(
+      logMessages.some((msg) => msg.includes('1.')),
+      `Expected rank 1 in results, got: ${JSON.stringify(logMessages)}`,
+    );
+    assert.ok(
+      !logMessages.some((msg) => msg.includes('2.')),
+      `Expected only 1 result, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/transfer-confirm.test.ts
+++ b/modules/economy-utils/test/transfer-confirm.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// NOTE: Tests in this suite are intentionally sequential and order-dependent.
+// The 'should complete transfer after confirmtransfer' test relies on the pending transfer
+// created by the 'should prompt for confirmation' test. This is an accepted pattern for
+// expensive integration test setups where recreating state per test would be prohibitively slow.
+describe('economy-utils: /transfer with pendingAmount confirmation', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let receiverName: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with pending amount of 100 (transfers >= 100 require confirmation)
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 100,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give player[0] starting currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Look up player[1]'s name for use in command messages
+    const player1Data = await client.player.playerControllerGetOne(ctx.players[1].playerId);
+    receiverName = player1Data.data.data.name;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should prompt for confirmation when amount >= pendingAmount', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 100`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected pending confirmation to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('confirmtransfer') || msg.includes('confirm')),
+      `Expected confirmation prompt, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should fail confirmtransfer when no pending transfer exists', async () => {
+    // player[1] has no pending transfer
+    const player = ctx.players[1]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}confirmtransfer`,
+      playerId: player.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected confirmtransfer to fail with no pending transfer');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('no pending transfer')),
+      `Expected no pending transfer error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should complete transfer after confirmtransfer with correct balances', async () => {
+    // player[0] already has a pending transfer from the first test
+    const sender = ctx.players[0]!;
+    const receiver = ctx.players[1]!;
+
+    // Get balances before confirming
+    const [senderBefore, receiverBefore] = await Promise.all([
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [sender.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [receiver.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+    ]);
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}confirmtransfer`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected confirmtransfer to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('successfully transferred')),
+      `Expected successful transfer log, got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify exact balances after transfer (no tax configured)
+    const [senderAfter, receiverAfter] = await Promise.all([
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [sender.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [receiver.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+    ]);
+
+    assert.equal(senderAfter, senderBefore - 100, `Sender should lose 100. Before: ${senderBefore}, After: ${senderAfter}`);
+    assert.equal(receiverAfter, receiverBefore + 100, `Receiver should gain 100. Before: ${receiverBefore}, After: ${receiverAfter}`);
+  });
+});

--- a/modules/economy-utils/test/transfer-maxamount.test.ts
+++ b/modules/economy-utils/test/transfer-maxamount.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /transfer with maxTransferAmount', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let receiverName: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with max transfer of 50
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 50,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give player[0] starting currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Look up player[1]'s name for use in command messages
+    const player1Data = await client.player.playerControllerGetOne(ctx.players[1].playerId);
+    receiverName = player1Data.data.data.name;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should reject transfer above maxTransferAmount', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 100`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected transfer to fail due to max transfer limit');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('cannot transfer more than') || msg.includes('50')),
+      `Expected max transfer error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should allow transfer at exactly maxTransferAmount', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 50`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected transfer at exactly max amount to succeed');
+  });
+});

--- a/modules/economy-utils/test/transfer-notax.test.ts
+++ b/modules/economy-utils/test/transfer-notax.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// NOTE: Tests in this suite are intentionally sequential and order-dependent.
+// The 'should fail with insufficient balance' test assumes player[0] has 400 remaining
+// from the previous transfer of 100. This is an accepted pattern for expensive integration
+// test setups where recreating state per test would be prohibitively slow.
+describe('economy-utils: /transfer command (no tax)', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let receiverName: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give player[0] starting currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Look up player[1]'s name for use in command messages
+    const player1Data = await client.player.playerControllerGetOne(ctx.players[1].playerId);
+    receiverName = player1Data.data.data.name;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should transfer currency from one player to another', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 100`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected transfer to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('successfully transferred') && msg.includes('100')),
+      `Expected transfer success log, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should fail transfer when sender has insufficient balance', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    // player[0] now has 400 (500 - 100 from previous test)
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 99999`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected transfer to fail with insufficient balance');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('enough balance')),
+      `Expected insufficient balance error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/transfer-tax.test.ts
+++ b/modules/economy-utils/test/transfer-tax.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /transfer with tax', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let receiverName: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with 10% transfer tax
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0.1,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give player[0] starting currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Look up player[1]'s name for use in command messages
+    const player1Data = await client.player.playerControllerGetOne(ctx.players[1].playerId);
+    receiverName = player1Data.data.data.name;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should apply tax during transfer (10% tax on 100 = receiver gets 90)', async () => {
+    const sender = ctx.players[0]!;
+    const receiver = ctx.players[1]!;
+
+    // Get balances before transfer
+    const [senderBefore, receiverBefore] = await Promise.all([
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [sender.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [receiver.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+    ]);
+
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 100`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected transfer with tax to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('tax') && msg.includes('10') && msg.includes('90')),
+      `Expected log to mention tax deduction (10 tax, 90 received), got: ${JSON.stringify(logMessages)}`,
+    );
+
+    // Verify exact balances after transfer
+    // tax = ceil(100 * 0.1) = 10, receiver gets 90, sender loses 100
+    const [senderAfter, receiverAfter] = await Promise.all([
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [sender.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+      client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [receiver.playerId] },
+      }).then((r) => r.data.data[0]?.currency ?? 0),
+    ]);
+
+    assert.equal(senderAfter, senderBefore - 100, `Sender should lose 100. Before: ${senderBefore}, After: ${senderAfter}`);
+    assert.equal(receiverAfter, receiverBefore + 90, `Receiver should gain 90. Before: ${receiverBefore}, After: ${receiverAfter}`);
+  });
+});

--- a/modules/economy-utils/test/transfer-validation.test.ts
+++ b/modules/economy-utils/test/transfer-validation.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: /transfer input validation', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let senderName: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 1,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Give player[0] starting currency
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+
+    // Look up player[0]'s own name (for self-transfer test)
+    const player0Data = await client.player.playerControllerGetOne(ctx.players[0].playerId);
+    senderName = player0Data.data.data.name;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should reject self-transfer', async () => {
+    const sender = ctx.players[0]!;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${senderName} 100`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected self-transfer to fail');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.toLowerCase().includes('cannot transfer currency to yourself')),
+      `Expected self-transfer error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should reject transfer of zero amount', async () => {
+    const sender = ctx.players[0]!;
+    const receiverData = await client.player.playerControllerGetOne(ctx.players[1].playerId);
+    const receiverName = receiverData.data.data.name;
+    const before = new Date();
+
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}transfer ${receiverName} 0`,
+      playerId: sender.playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a command-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, false, 'Expected zero-amount transfer to fail');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.toLowerCase().includes('positive whole number')),
+      `Expected positive whole number error, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+});

--- a/modules/economy-utils/test/zombie-kill-reward.test.ts
+++ b/modules/economy-utils/test/zombie-kill-reward.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+describe('economy-utils: zombie-kill-reward cron job', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let zombieCronId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        pendingAmount: 0,
+        zombieKillReward: 5,
+        transferTax: 0,
+        maxTransferAmount: 0,
+        showBalanceOnLogin: false,
+      },
+    });
+
+    // Find the zombie-kill-reward cron job by versionId and name
+    const cronJobs = await client.cronjob.cronJobControllerSearch({
+      filters: { versionId: [versionId], name: ['zombie-kill-reward'] },
+    });
+    const zombieCron = cronJobs.data.data.find((c) => c.name === 'zombie-kill-reward');
+    assert.ok(zombieCron, 'Expected zombie-kill-reward cron job to exist after install');
+    zombieCronId = zombieCron.id;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('should run the cron job and award currency for entity kills', async () => {
+    const player = ctx.players[0]!;
+    const killBefore = new Date();
+
+    // Trigger an entity kill event
+    await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+    // Wait for the kill event to be stored before triggering cron
+    await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.EntityKilled,
+      gameserverId: ctx.gameServer.id,
+      after: killBefore,
+      timeout: 15000,
+    });
+
+    // Manually trigger the cron job
+    const cronBefore = new Date();
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx.gameServer.id,
+      cronjobId: zombieCronId,
+      moduleId: moduleId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: cronBefore,
+      timeout: 30000,
+    });
+
+    assert.ok(event, 'Expected a cronjob-executed event');
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    assert.equal(meta?.result?.success, true, 'Expected cron job to succeed');
+
+    const logMessages = (meta?.result?.logs ?? []).map((l) => l.msg);
+    assert.ok(
+      logMessages.some((msg) => msg.includes('kill events')),
+      `Expected kill events log, got: ${JSON.stringify(logMessages)}`,
+    );
+  });
+
+  it('should apply ZOMBIE_KILL_REWARD_OVERRIDE permission to override reward per kill', async () => {
+    const player = ctx.players[1]!;
+    const expectedOverrideReward = 10;
+
+    // Grant player[1] override of 10 per kill (base is 5)
+    const overrideRoleId = await assignPermissions(client, player.playerId, ctx.gameServer.id, [
+      { code: 'ZOMBIE_KILL_REWARD_OVERRIDE', count: expectedOverrideReward },
+    ]);
+
+    try {
+      // Get player[1]'s current balance
+      const pogBefore = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+      });
+      const balanceBefore = pogBefore.data.data[0]?.currency ?? 0;
+
+      const killBefore = new Date();
+
+      // Trigger a kill for player[1]
+      await ctx.server.executeConsoleCommand(`triggerKill ${player.gameId}`);
+
+      // Wait for the kill event to be stored before triggering cron
+      await waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.EntityKilled,
+        gameserverId: ctx.gameServer.id,
+        after: killBefore,
+        timeout: 15000,
+      });
+
+      // Trigger the cron job
+      const cronBefore = new Date();
+      await client.cronjob.cronJobControllerTrigger({
+        gameServerId: ctx.gameServer.id,
+        cronjobId: zombieCronId,
+        moduleId: moduleId,
+      });
+
+      const event = await waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+        gameserverId: ctx.gameServer.id,
+        after: cronBefore,
+        timeout: 30000,
+      });
+
+      assert.ok(event, 'Expected a cronjob-executed event');
+      const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+      assert.equal(meta?.result?.success, true, 'Expected cron job to succeed with override');
+
+      // Verify player[1] received exactly 10 (override) not 5 (default)
+      const pogAfter = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+      });
+      const balanceAfter = pogAfter.data.data[0]?.currency ?? 0;
+
+      assert.equal(
+        balanceAfter - balanceBefore,
+        expectedOverrideReward,
+        `Expected balance to increase by exactly ${expectedOverrideReward} (override). Before: ${balanceBefore}, After: ${balanceAfter}`,
+      );
+    } finally {
+      await cleanupRole(client, overrideRoleId);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Migrates the built-in `economyUtils` module from `@takaro/modules` to a community module
- 8 commands: balance, transfer, confirmtransfer, topcurrency, grantcurrency, revokecurrency, shop, claim
- 1 hook: on-login-balance (shows balance when player connects)
- 1 cron job: zombie-kill-reward (awards currency for entity kills)
- New features: transfer tax (economy sink), max transfer amount, balance on login, configurable leaderboard size, pending transfer expiry, failed refund audit trail

Closes gettakaro/community-modules-viewer#233

## Test plan

- [ ] `npm run build` passes
- [ ] `npm test` — 26 economy-utils tests pass (12 test files covering all commands, hook, and cron)
- [ ] In-game verification with bot service for key commands (balance, transfer, shop, grantcurrency)