### PR TITLE
Add rotating server-messages module with persisted broadcast state

### DIFF
--- a/modules/server-messages/module.json
+++ b/modules/server-messages/module.json
@@ -1,0 +1,55 @@
+{
+  "name": "test-server-messages",
+  "description": "Broadcasts rotating server announcements to online players on a schedule.",
+  "version": "latest",
+  "supportedGames": [
+    "all"
+  ],
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "messages": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "Welcome!",
+          "Join our Discord!",
+          "Type /help for commands"
+        ],
+        "description": "Messages to rotate through"
+      },
+      "mode": {
+        "type": "string",
+        "enum": [
+          "sequential",
+          "random"
+        ],
+        "default": "sequential",
+        "description": "How to select the next announcement"
+      },
+      "minPlayers": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Minimum online players required before broadcasting (0 disables the threshold, but broadcasts still skip when nobody is online)"
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "cronJobs": {
+    "broadcast-message": {
+      "temporalValue": "*/30 * * * *",
+      "description": "Broadcast a rotating announcement to all online players",
+      "function": "src/cronjobs/broadcast-message/index.js"
+    }
+  },
+  "functions": {
+    "server-messages-helpers": {
+      "function": "src/functions/server-messages-helpers.js"
+    }
+  }
+}

--- a/modules/server-messages/src/cronjobs/broadcast-message/index.js
+++ b/modules/server-messages/src/cronjobs/broadcast-message/index.js
@@ -46,12 +46,13 @@ async function main() {
   }
 
   let selectedIndex = 0;
+  let nextSequentialIndex;
   if (mode === 'random') {
     selectedIndex = Math.floor(Math.random() * messages.length);
   } else {
     const currentIndex = await getMessageIndex(gameServerId, mod.moduleId);
     selectedIndex = currentIndex % messages.length;
-    await setMessageIndex(gameServerId, mod.moduleId, (selectedIndex + 1) % messages.length);
+    nextSequentialIndex = (selectedIndex + 1) % messages.length;
   }
 
   let resolvedMessage = messages[selectedIndex];
@@ -70,6 +71,10 @@ async function main() {
     message: resolvedMessage,
     opts: {},
   });
+
+  if (mode === 'sequential') {
+    await setMessageIndex(gameServerId, mod.moduleId, nextSequentialIndex);
+  }
 
   console.log(
     `broadcast-message: sent message (mode=${mode}, index=${selectedIndex}, onlineCount=${onlineCount}): ${resolvedMessage}`,

--- a/modules/server-messages/src/cronjobs/broadcast-message/index.js
+++ b/modules/server-messages/src/cronjobs/broadcast-message/index.js
@@ -1,0 +1,79 @@
+import { data, takaro } from '@takaro/helpers';
+import { getMessageIndex, setMessageIndex, resolveTemplates } from './server-messages-helpers.js';
+
+function normalizeConfig(userConfig = {}) {
+  const messages = Array.isArray(userConfig.messages)
+    ? userConfig.messages.filter((msg) => typeof msg === 'string').map((msg) => msg.trim()).filter(Boolean)
+    : [];
+
+  const mode = userConfig.mode === 'random' ? 'random' : 'sequential';
+  const minPlayers = Number.isFinite(userConfig.minPlayers) && userConfig.minPlayers > 0
+    ? Math.floor(userConfig.minPlayers)
+    : 0;
+
+  return { messages, mode, minPlayers };
+}
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const { messages, mode, minPlayers } = normalizeConfig(mod.userConfig ?? {});
+
+  if (messages.length === 0) {
+    console.log('broadcast-message: skipping — no messages configured');
+    return;
+  }
+
+  const playerSearch = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+    filters: {
+      gameServerId: [gameServerId],
+      online: [true],
+    },
+    page: 0,
+    limit: 1,
+  });
+
+  const onlineCount = playerSearch.data.meta.total ?? 0;
+  if (onlineCount === 0) {
+    console.log('broadcast-message: skipping — no players online');
+    return;
+  }
+
+  if (minPlayers > 0 && onlineCount < minPlayers) {
+    console.log(
+      `broadcast-message: skipping — online player count ${onlineCount} is below minPlayers ${minPlayers}`,
+    );
+    return;
+  }
+
+  let selectedIndex = 0;
+  if (mode === 'random') {
+    selectedIndex = Math.floor(Math.random() * messages.length);
+  } else {
+    const currentIndex = await getMessageIndex(gameServerId, mod.moduleId);
+    selectedIndex = currentIndex % messages.length;
+    await setMessageIndex(gameServerId, mod.moduleId, (selectedIndex + 1) % messages.length);
+  }
+
+  let resolvedMessage = messages[selectedIndex];
+  const templateVars = {
+    playerCount: onlineCount,
+  };
+
+  if (resolvedMessage.includes('{serverName}')) {
+    const gameServer = (await takaro.gameserver.gameServerControllerGetOne(gameServerId)).data.data;
+    templateVars.serverName = gameServer?.name ?? 'Unknown Server';
+  }
+
+  resolvedMessage = resolveTemplates(resolvedMessage, templateVars);
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: resolvedMessage,
+    opts: {},
+  });
+
+  console.log(
+    `broadcast-message: sent message (mode=${mode}, index=${selectedIndex}, onlineCount=${onlineCount}): ${resolvedMessage}`,
+  );
+}
+
+await main();

--- a/modules/server-messages/src/cronjobs/broadcast-message/index.js
+++ b/modules/server-messages/src/cronjobs/broadcast-message/index.js
@@ -8,7 +8,7 @@ function normalizeConfig(userConfig = {}) {
 
   const mode = userConfig.mode === 'random' ? 'random' : 'sequential';
   const minPlayers = Number.isFinite(userConfig.minPlayers) && userConfig.minPlayers > 0
-    ? Math.floor(userConfig.minPlayers)
+    ? userConfig.minPlayers
     : 0;
 
   return { messages, mode, minPlayers };

--- a/modules/server-messages/src/functions/server-messages-helpers.js
+++ b/modules/server-messages/src/functions/server-messages-helpers.js
@@ -1,0 +1,55 @@
+import { takaro } from '@takaro/helpers';
+
+export const SERVER_MESSAGES_INDEX_KEY = 'server_messages_index';
+
+async function findVariable(gameServerId, moduleId, key) {
+  const res = await takaro.variable.variableControllerSearch({
+    filters: {
+      key: [key],
+      gameServerId: [gameServerId],
+      moduleId: [moduleId],
+    },
+  });
+
+  return res.data.data.length > 0 ? res.data.data[0] : null;
+}
+
+export async function getMessageIndex(gameServerId, moduleId) {
+  const variable = await findVariable(gameServerId, moduleId, SERVER_MESSAGES_INDEX_KEY);
+  if (!variable) return 0;
+
+  try {
+    const parsed = Math.floor(JSON.parse(variable.value));
+    return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+  } catch (err) {
+    console.error(`server-messages-helpers: failed to parse stored message index, defaulting to 0. Error: ${err}`);
+    return 0;
+  }
+}
+
+export async function setMessageIndex(gameServerId, moduleId, index) {
+  const safeIndex = Number.isFinite(index) && index >= 0 ? Math.floor(index) : 0;
+  const serialized = JSON.stringify(safeIndex);
+  const existing = await findVariable(gameServerId, moduleId, SERVER_MESSAGES_INDEX_KEY);
+
+  if (existing) {
+    await takaro.variable.variableControllerUpdate(existing.id, { value: serialized });
+  } else {
+    await takaro.variable.variableControllerCreate({
+      key: SERVER_MESSAGES_INDEX_KEY,
+      value: serialized,
+      gameServerId,
+      moduleId,
+    });
+  }
+}
+
+export function resolveTemplates(message, vars = {}) {
+  if (typeof message !== 'string' || message.length === 0) return '';
+
+  return message.replace(/\{(\w+)\}/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, key)) return match;
+    const value = vars[key];
+    return value === undefined || value === null ? '' : String(value);
+  });
+}

--- a/modules/server-messages/test/broadcast-message.test.ts
+++ b/modules/server-messages/test/broadcast-message.test.ts
@@ -109,6 +109,23 @@ describe('server-messages: broadcast-message cronjob', () => {
     return res.data.meta.total ?? 0;
   }
 
+  async function waitForOnlinePlayerCount(expectedCount: number): Promise<void> {
+    const maxWaitMs = 30000;
+    const pollIntervalMs = 2000;
+    const start = Date.now();
+
+    while (Date.now() - start < maxWaitMs) {
+      const onlineCount = await getOnlinePlayerCount();
+      if (onlineCount === expectedCount) {
+        return;
+      }
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+    }
+
+    const finalCount = await getOnlinePlayerCount();
+    throw new Error(`Timed out waiting for online player count ${expectedCount}; final count was ${finalCount}`);
+  }
+
   async function triggerBroadcast(): Promise<{ success: boolean; logs: string[] }> {
     const before = new Date();
 
@@ -216,6 +233,30 @@ describe('server-messages: broadcast-message cronjob', () => {
       logs.some((msg) => msg.includes('below minPlayers 999')),
       `Expected minPlayers skip log, got: ${JSON.stringify(logs)}`,
     );
+  });
+
+  it('skips when no players are online', async () => {
+    await reinstallModule({
+      messages: ['Anyone there?'],
+      mode: 'sequential',
+      minPlayers: 0,
+    });
+
+    await ctx.server.executeConsoleCommand('disconnectAll');
+    await waitForOnlinePlayerCount(0);
+
+    try {
+      const { success, logs } = await triggerBroadcast();
+
+      assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+      assert.ok(
+        logs.some((msg) => msg.includes('skipping') && msg.includes('no players online')),
+        `Expected no-players-online skip log, got: ${JSON.stringify(logs)}`,
+      );
+    } finally {
+      await ctx.server.executeConsoleCommand('connectAll');
+      await waitForOnlinePlayerCount(ctx.players.length);
+    }
   });
 
   it('template variables resolve playerCount using live player data', async () => {

--- a/modules/server-messages/test/broadcast-message.test.ts
+++ b/modules/server-messages/test/broadcast-message.test.ts
@@ -235,6 +235,29 @@ describe('server-messages: broadcast-message cronjob', () => {
     );
   });
 
+  it('honors fractional minPlayers thresholds without rounding down', async () => {
+    const expectedOnlineCount = await getOnlinePlayerCount();
+    const minPlayers = expectedOnlineCount + 0.1;
+
+    await reinstallModule({
+      messages: ['Need just a bit more'],
+      mode: 'sequential',
+      minPlayers,
+    });
+
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes(`below minPlayers ${minPlayers}`)),
+      `Expected fractional minPlayers skip log, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      logs.every((msg) => !msg.includes('sent message')),
+      `Expected no broadcast when onlineCount=${expectedOnlineCount} and minPlayers=${minPlayers}, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
   it('skips when no players are online', async () => {
     await reinstallModule({
       messages: ['Anyone there?'],

--- a/modules/server-messages/test/broadcast-message.test.ts
+++ b/modules/server-messages/test/broadcast-message.test.ts
@@ -96,6 +96,19 @@ describe('server-messages: broadcast-message cronjob', () => {
     await new Promise((resolve) => setTimeout(resolve, 1000));
   }
 
+  async function getOnlinePlayerCount(): Promise<number> {
+    const res = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: {
+        gameServerId: [ctx.gameServer.id],
+        online: [true],
+      },
+      page: 0,
+      limit: 1,
+    });
+
+    return res.data.meta.total ?? 0;
+  }
+
   async function triggerBroadcast(): Promise<{ success: boolean; logs: string[] }> {
     const before = new Date();
 
@@ -205,19 +218,38 @@ describe('server-messages: broadcast-message cronjob', () => {
     );
   });
 
-  it('template variables resolve', async () => {
+  it('template variables resolve playerCount using live player data', async () => {
     await reinstallModule({
       messages: ['There are {playerCount} players online'],
       mode: 'sequential',
       minPlayers: 0,
     });
 
+    const expectedOnlineCount = await getOnlinePlayerCount();
     const { success, logs } = await triggerBroadcast();
 
     assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
     assert.ok(
-      logs.some((msg) => msg.includes(`There are ${ctx.players.length} players online`)),
-      `Expected playerCount template to resolve to ${ctx.players.length}, got: ${JSON.stringify(logs)}`,
+      logs.some((msg) => msg.includes(`There are ${expectedOnlineCount} players online`)),
+      `Expected playerCount template to resolve to ${expectedOnlineCount}, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('template variables resolve serverName', async () => {
+    await reinstallModule({
+      messages: ['Welcome to {serverName}'],
+      mode: 'sequential',
+      minPlayers: 0,
+    });
+
+    const gameServer = (await client.gameserver.gameServerControllerGetOne(ctx.gameServer.id)).data.data;
+    const expectedServerName = gameServer?.name ?? 'Unknown Server';
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes(`Welcome to ${expectedServerName}`)),
+      `Expected serverName template to resolve to ${expectedServerName}, got: ${JSON.stringify(logs)}`,
     );
   });
 });

--- a/modules/server-messages/test/broadcast-message.test.ts
+++ b/modules/server-messages/test/broadcast-message.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  cleanupTestModules,
+  cleanupTestGameServers,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+const INDEX_KEY = 'server_messages_index';
+
+describe('server-messages: broadcast-message cronjob', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let cronjobId: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const maxWaitForAll = 30000;
+    const pollIntervalMs = 2000;
+    const setupStart = Date.now();
+    while (ctx.players.length < 3 && Date.now() - setupStart < maxWaitForAll) {
+      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+      const res = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+      });
+      if (res.data.data.length >= 3) {
+        ctx.players = res.data.data;
+        break;
+      }
+    }
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    const cronjob = mod.latestVersion.cronJobs[0];
+    if (!cronjob) throw new Error('Expected at least one cronjob in server-messages module');
+    cronjobId = cronjob.id;
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  async function clearMessageIndex(): Promise<void> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: [INDEX_KEY],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+      },
+    });
+
+    for (const variable of vars.data.data) {
+      await client.variable.variableControllerDelete(variable.id);
+    }
+  }
+
+  async function reinstallModule(userConfig: Record<string, unknown>): Promise<void> {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch {
+      // Ignore if module was not installed yet.
+    }
+
+    await installModule(client, versionId, ctx.gameServer.id, { userConfig });
+    await clearMessageIndex();
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  }
+
+  async function triggerBroadcast(): Promise<{ success: boolean; logs: string[] }> {
+    const before = new Date();
+
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx.gameServer.id,
+      cronjobId,
+      moduleId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    const success = meta?.result?.success ?? false;
+    const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+
+    return { success, logs };
+  }
+
+  it('sequential cycles in order', async () => {
+    await reinstallModule({
+      messages: ['Alpha', 'Beta', 'Gamma'],
+      mode: 'sequential',
+      minPlayers: 0,
+    });
+
+    const run1 = await triggerBroadcast();
+    const run2 = await triggerBroadcast();
+    const run3 = await triggerBroadcast();
+    const run4 = await triggerBroadcast();
+
+    for (const run of [run1, run2, run3, run4]) {
+      assert.equal(run.success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(run.logs)}`);
+    }
+
+    assert.ok(
+      run1.logs.some((msg) => msg.includes('index=0') && msg.includes('Alpha')),
+      `Expected first run to send Alpha at index=0, got: ${JSON.stringify(run1.logs)}`,
+    );
+    assert.ok(
+      run2.logs.some((msg) => msg.includes('index=1') && msg.includes('Beta')),
+      `Expected second run to send Beta at index=1, got: ${JSON.stringify(run2.logs)}`,
+    );
+    assert.ok(
+      run3.logs.some((msg) => msg.includes('index=2') && msg.includes('Gamma')),
+      `Expected third run to send Gamma at index=2, got: ${JSON.stringify(run3.logs)}`,
+    );
+    assert.ok(
+      run4.logs.some((msg) => msg.includes('index=0') && msg.includes('Alpha')),
+      `Expected fourth run to wrap to Alpha at index=0, got: ${JSON.stringify(run4.logs)}`,
+    );
+  });
+
+  it('random selects a message', async () => {
+    await reinstallModule({
+      messages: ['Red', 'Green', 'Amber'],
+      mode: 'random',
+      minPlayers: 0,
+    });
+
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) =>
+        msg.includes('mode=random') && ['Red', 'Green', 'Amber'].some((candidate) => msg.includes(candidate)),
+      ),
+      `Expected a random broadcast log containing one configured message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('empty messages skips', async () => {
+    await reinstallModule({
+      messages: [],
+      mode: 'sequential',
+      minPlayers: 0,
+    });
+
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('skipping') && msg.includes('no messages configured')),
+      `Expected empty-message skip log, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('minPlayers threshold skips', async () => {
+    await reinstallModule({
+      messages: ['Need a crowd'],
+      mode: 'sequential',
+      minPlayers: 999,
+    });
+
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('below minPlayers 999')),
+      `Expected minPlayers skip log, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('template variables resolve', async () => {
+    await reinstallModule({
+      messages: ['There are {playerCount} players online'],
+      mode: 'sequential',
+      minPlayers: 0,
+    });
+
+    const { success, logs } = await triggerBroadcast();
+
+    assert.equal(success, true, `Expected cronjob to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes(`There are ${ctx.players.length} players online`)),
+      `Expected playerCount template to resolve to ${ctx.players.length}, got: ${JSON.stringify(logs)}`,
+    );
+  });
+});


### PR DESCRIPTION
> ⚠️ This PR was created automatically by the adversary orchestrator. Do not merge without human review.

## Summary

Closes #19

- Adds a new `modules/server-messages` Takaro module that broadcasts scheduled announcements to online players with configurable message lists, sequential/random selection, and a minimum-player threshold.
- Implements helper functions for persisted sequential rotation state via Takaro variables and lightweight template resolution for placeholders like `{playerCount}` and `{serverName}`.
- Hardens the cronjob flow with early skips for empty configs, zero-player servers, and unmet `minPlayers` thresholds, while only advancing the sequential index after a successful broadcast.
- Adds end-to-end integration coverage for rotation order, random mode, empty-message skips, zero-player skips, fractional `minPlayers` handling, and template expansion against the real Takaro API/mock server setup.

## Reviewer Guide

Start with `modules/server-messages/module.json` to confirm the intended public surface area: config schema, cron schedule, and exported function wiring. Then review `src/cronjobs/broadcast-message/index.js`, since it contains the main behavior: config normalization, online-player lookup, guard clauses, message selection, template hydration, send, and state persistence. After that, check `src/functions/server-messages-helpers.js` for the Takaro variable persistence pattern and template replacement behavior. Finally, read `test/broadcast-message.test.ts` to verify the implementation matches the expected integration behavior, especially the gotchas introduced in follow-up commits: sequential state should advance only after a send succeeds, and fractional `minPlayers` values should be honored instead of rounded down.

## Test Plan

Run `npm run build && npm test`.

New integration coverage lives in `modules/server-messages/test/broadcast-message.test.ts` and exercises:
- sequential rotation wrapping across repeated cronjob triggers
- random selection mode
- skip behavior for empty `messages`
- skip behavior when no players are online
- `minPlayers` threshold enforcement, including fractional thresholds
- template resolution for `{playerCount}` and `{serverName}`

Manual verification: install the module on the Paper server, connect bots, trigger the cronjob, and confirm broadcasts appear in-game only when players are online and thresholds are met.

<details>
<summary>Orchestration metadata</summary>

| Field | Value |
|-------|-------|
| Plan | `/home/catalysm/.claude/plans/federated-sauteeing-mitten.md` |
| Branch | `adversary/20260411-190556-plan-servermessages-module-issue-19` |
| Base | `main` |
| Turns | 4 |
| Threshold | 2 |
| Outcome | ✓ Clean — zero threshold findings |

### Threshold Findings (severity >= 2)

_None._

### Below-Threshold Findings (severity < 2)

_None._

Artifacts: `/home/catalysm/code/takaro/ai-module-writer/.pi-adversary/runs/20260411-190556-plan-servermessages-module-issue-19`

</details>
