### PR TITLE
Add mini-games module (Wordle, Hangman, Trivia, and more)

### DIFF
--- a/modules/mini-games/module.json
+++ b/modules/mini-games/module.json
@@ -1,0 +1,384 @@
+{
+  "name": "test-mini-games",
+  "description": "Unified mini-games module with daily puzzles (Wordle, Hangman, Hot/Cold) and live chat rounds (Trivia, Scramble, Math race, Reaction race). Skill-based, point-scoring, optional currency rewards, boost tiers, cross-game leaderboards.",
+  "version": "latest",
+  "supportedGames": ["all"],
+
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "liveRoundIntervalMinutes": {
+        "type": "number",
+        "default": 30,
+        "minimum": 5,
+        "description": "Minimum minutes between automatic live rounds."
+      },
+      "minPlayersForLiveRound": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Minimum online players required to fire a live round."
+      },
+      "liveRoundAnswerWindowSec": {
+        "type": "number",
+        "default": 60,
+        "minimum": 15,
+        "description": "How long players have to answer a live round."
+      },
+      "pointsToCurrencyRate": {
+        "type": "number",
+        "default": 0,
+        "description": "Currency paid per point. 0 disables currency rewards."
+      },
+      "dailyPointsCapPerPlayer": {
+        "type": "number",
+        "default": 0,
+        "description": "Max points per UTC day per player. 0 = unlimited."
+      },
+      "bigScoreThreshold": {
+        "type": "number",
+        "default": 500,
+        "description": "Scores at/above this emit a chat announcement."
+      },
+      "pointsWordleBase": {
+        "type": "number",
+        "default": 100
+      },
+      "pointsHangmanBase": {
+        "type": "number",
+        "default": 80
+      },
+      "pointsHotColdBase": {
+        "type": "number",
+        "default": 60
+      },
+      "pointsTriviaWin": {
+        "type": "number",
+        "default": 40
+      },
+      "pointsScrambleWin": {
+        "type": "number",
+        "default": 40
+      },
+      "pointsMathRaceWin": {
+        "type": "number",
+        "default": 40
+      },
+      "pointsReactionRaceWin": {
+        "type": "number",
+        "default": 20
+      },
+      "triviaQuestionSource": {
+        "type": "string",
+        "enum": ["api", "custom"],
+        "default": "api",
+        "description": "Trivia source. 'api' fetches from Open Trivia DB; falls back to custom bank on failure."
+      },
+      "triviaApiCategory": {
+        "type": "array",
+        "default": ["any"],
+        "items": { "type": "string" },
+        "description": "OpenTDB category keys. ['any'] = no filter. Multiple = random pick per round."
+      },
+      "triviaApiDifficulty": {
+        "type": "string",
+        "enum": ["any", "easy", "medium", "hard"],
+        "default": "any"
+      },
+      "triviaApiType": {
+        "type": "string",
+        "enum": ["any", "multiple", "boolean"],
+        "default": "any"
+      },
+      "games": {
+        "type": "object",
+        "properties": {
+          "wordle":       { "type": "boolean", "default": true },
+          "hangman":      { "type": "boolean", "default": true },
+          "hotcold":      { "type": "boolean", "default": true },
+          "trivia":       { "type": "boolean", "default": true },
+          "scramble":     { "type": "boolean", "default": true },
+          "mathrace":     { "type": "boolean", "default": true },
+          "reactionrace": { "type": "boolean", "default": true }
+        },
+        "default": {
+          "wordle": true,
+          "hangman": true,
+          "hotcold": true,
+          "trivia": true,
+          "scramble": true,
+          "mathrace": true,
+          "reactionrace": true
+        }
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+
+  "uiSchema": {},
+
+  "permissions": [
+    {
+      "permission": "MINIGAMES_PLAY",
+      "friendlyName": "Play mini-games",
+      "description": "Allowed to play mini-games.",
+      "canHaveCount": false
+    },
+    {
+      "permission": "MINIGAMES_BOOST",
+      "friendlyName": "Mini-games boost tier",
+      "description": "+25% points per count (count 1-4, cap = 2.0x).",
+      "canHaveCount": true
+    },
+    {
+      "permission": "MINIGAMES_MANAGE",
+      "friendlyName": "Manage mini-games",
+      "description": "Admin commands: ban, reset, skip round, fire round, report.",
+      "canHaveCount": false
+    }
+  ],
+
+  "commands": {
+    "minigames": {
+      "trigger": "minigames",
+      "description": "Help and overview for mini-games.",
+      "helpText": "Usage: /minigames [game] — Show help for all games or a specific game.",
+      "function": "src/commands/minigames/index.js",
+      "arguments": [
+        {
+          "name": "game",
+          "type": "string",
+          "helpText": "Optional game name to show rules for.",
+          "defaultValue": "all",
+          "position": 0
+        }
+      ]
+    },
+    "wordle": {
+      "trigger": "wordle",
+      "description": "Daily 5-letter word puzzle.",
+      "helpText": "Usage: /wordle [guess] — No arg shows today's attempts; with 5-letter guess submits a guess.",
+      "function": "src/commands/wordle/index.js",
+      "arguments": [
+        {
+          "name": "guess",
+          "type": "string",
+          "helpText": "Your 5-letter guess.",
+          "defaultValue": "__status__",
+          "position": 0
+        }
+      ]
+    },
+    "hangman": {
+      "trigger": "hangman",
+      "description": "Daily hangman puzzle.",
+      "helpText": "Usage: /hangman [letter|word] — No arg shows board; letter guesses a letter; full word attempts solve.",
+      "function": "src/commands/hangman/index.js",
+      "arguments": [
+        {
+          "name": "letterOrWord",
+          "type": "string",
+          "helpText": "A single letter or the full word.",
+          "defaultValue": "__status__",
+          "position": 0
+        }
+      ]
+    },
+    "hotcold": {
+      "trigger": "hotcold",
+      "description": "Daily hot/cold number guessing game.",
+      "helpText": "Usage: /hotcold [number] — No arg shows attempts; number 1-1000 submits a guess.",
+      "function": "src/commands/hotcold/index.js",
+      "arguments": [
+        {
+          "name": "number",
+          "type": "number",
+          "helpText": "Your guess (1-1000).",
+          "defaultValue": "0",
+          "position": 0
+        }
+      ]
+    },
+    "answer": {
+      "trigger": "answer",
+      "description": "Answer the currently active live round.",
+      "helpText": "Usage: /answer <response> — Submit your answer to the active live round.",
+      "function": "src/commands/answer/index.js",
+      "arguments": [
+        {
+          "name": "response",
+          "type": "string",
+          "helpText": "Your answer to the active live round.",
+          "position": 0
+        }
+      ]
+    },
+    "minigamestats": {
+      "trigger": "minigamestats",
+      "description": "View mini-games stats.",
+      "helpText": "Usage: /minigamestats [player] — Show lifetime and current-day stats.",
+      "function": "src/commands/minigamestats/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "string",
+          "helpText": "Player name to look up (default: yourself).",
+          "defaultValue": "self",
+          "position": 0
+        }
+      ]
+    },
+    "minigamestop": {
+      "trigger": "minigamestop",
+      "description": "View mini-games leaderboards.",
+      "helpText": "Usage: /minigamestop <points|wordle|hangman|streak> — Show leaderboard.",
+      "function": "src/commands/minigamestop/index.js",
+      "arguments": [
+        {
+          "name": "category",
+          "type": "string",
+          "helpText": "Leaderboard category: points, wordle, hangman, or streak.",
+          "position": 0
+        }
+      ]
+    },
+    "puzzle": {
+      "trigger": "puzzle",
+      "description": "Status of today's async puzzles.",
+      "helpText": "Usage: /puzzle — Shows which daily puzzles you've played and time until rollover.",
+      "function": "src/commands/puzzle/index.js",
+      "arguments": []
+    },
+    "minigamesban": {
+      "trigger": "minigamesban",
+      "description": "Ban a player from mini-games.",
+      "helpText": "Usage: /minigamesban <player> [hours] — Ban permanently (no hours) or temporarily.",
+      "function": "src/commands/minigamesban/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "string",
+          "helpText": "Player gameId to ban.",
+          "position": 0
+        },
+        {
+          "name": "hours",
+          "type": "number",
+          "helpText": "Hours for temporary ban (omit for permanent).",
+          "defaultValue": "0",
+          "position": 1
+        }
+      ]
+    },
+    "minigamesunban": {
+      "trigger": "minigamesunban",
+      "description": "Unban a player from mini-games.",
+      "helpText": "Usage: /minigamesunban <player> — Remove a mini-games ban.",
+      "function": "src/commands/minigamesunban/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "string",
+          "helpText": "Player name to unban.",
+          "position": 0
+        }
+      ]
+    },
+    "minigamesresetstats": {
+      "trigger": "minigamesresetstats",
+      "description": "Reset a player's mini-games stats.",
+      "helpText": "Usage: /minigamesresetstats <player> — Wipe all stats for a player.",
+      "function": "src/commands/minigamesresetstats/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "string",
+          "helpText": "Player name whose stats to reset.",
+          "position": 0
+        }
+      ]
+    },
+    "minigamesskiproundnow": {
+      "trigger": "minigamesskiproundnow",
+      "description": "Cancel the current live round.",
+      "helpText": "Usage: /minigamesskiproundnow — Cancel the active live round with no winner.",
+      "function": "src/commands/minigamesskiproundnow/index.js",
+      "arguments": []
+    },
+    "minigamesfirenow": {
+      "trigger": "minigamesfirenow",
+      "description": "Fire a live round immediately.",
+      "helpText": "Usage: /minigamesfirenow [game] — Start a live round now, optionally picking the game.",
+      "function": "src/commands/minigamesfirenow/index.js",
+      "arguments": [
+        {
+          "name": "game",
+          "type": "string",
+          "helpText": "Game to fire (trivia, scramble, mathrace, reactionrace). Random if omitted.",
+          "position": 0
+        }
+      ]
+    },
+    "minigamesreport": {
+      "trigger": "minigamesreport",
+      "description": "PM admin with mini-games report.",
+      "helpText": "Usage: /minigamesreport — Send a lifetime stats report (total rounds, points, top 5, per-game breakdown).",
+      "function": "src/commands/minigamesreport/index.js",
+      "arguments": []
+    }
+  },
+
+  "hooks": {
+    "onChatMessage": {
+      "eventType": "chat-message",
+      "description": "Catch raw chat for Reaction race winner detection.",
+      "function": "src/hooks/on-chat-message/index.js"
+    },
+    "onPlayerDisconnect": {
+      "eventType": "player-disconnected",
+      "description": "Soft cleanup on player disconnect (sessions persist).",
+      "function": "src/hooks/on-player-disconnect/index.js"
+    }
+  },
+
+  "cronJobs": {
+    "rolloverDailyPuzzles": {
+      "temporalValue": "0 0 * * *",
+      "description": "At UTC midnight: pick new daily puzzles (Wordle, Hangman, Hot/Cold) and clear yesterday's sessions.",
+      "function": "src/cronjobs/rollover-daily-puzzles/index.js"
+    },
+    "fireLiveRound": {
+      "temporalValue": "*/5 * * * *",
+      "description": "If enough time elapsed and enough players online, fire a random enabled live game.",
+      "function": "src/cronjobs/fire-live-round/index.js"
+    },
+    "closeLiveRound": {
+      "temporalValue": "* * * * *",
+      "description": "If active live round has expired with no winner, close it and announce the answer.",
+      "function": "src/cronjobs/close-live-round/index.js"
+    },
+    "refreshLeaderboards": {
+      "temporalValue": "*/5 * * * *",
+      "description": "Aggregate player stats and write leaderboard cache.",
+      "function": "src/cronjobs/refresh-leaderboards/index.js"
+    },
+    "expireWindows": {
+      "temporalValue": "0 0 * * *",
+      "description": "Delete daily point window variables from the prior UTC day.",
+      "function": "src/cronjobs/expire-windows/index.js"
+    },
+    "expireBans": {
+      "temporalValue": "0 * * * *",
+      "description": "Remove temporary bans whose expiry timestamp has passed.",
+      "function": "src/cronjobs/expire-bans/index.js"
+    }
+  },
+
+  "functions": {
+    "mini-games-helpers": {
+      "function": "src/functions/mini-games-helpers.js"
+    }
+  }
+}

--- a/modules/mini-games/src/commands/answer/index.js
+++ b/modules/mini-games/src/commands/answer/index.js
@@ -1,0 +1,96 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getVariable, checkBanAndCap, awardPoints, clearActiveRound, normaliseAnswer, recordPlay,
+} from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  const round = await getVariable(gameServerId, moduleId, 'minigames_active_round');
+  if (!round) {
+    throw new TakaroUserError('There is no active live round right now. Wait for the next one!');
+  }
+
+  // Check if expired
+  if (round.expiresAt && new Date(round.expiresAt) < new Date()) {
+    throw new TakaroUserError('That round has already expired!');
+  }
+
+  const response = args.response ? String(args.response).trim() : '';
+  if (!response) {
+    throw new TakaroUserError('Please provide an answer. Usage: /answer <your answer>');
+  }
+
+  // Check ban/cap BEFORE doing any game logic — banned players must not be able to grief
+  await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+
+  const game = round.game;
+  let correct = false;
+
+  if (game === 'trivia' || game === 'scramble') {
+    correct = normaliseAnswer(response) === normaliseAnswer(round.answer);
+  } else if (game === 'mathrace') {
+    const guessNum = parseInt(response, 10);
+    correct = !isNaN(guessNum) && guessNum === round.answer;
+  } else if (game === 'reactionrace') {
+    // reaction race uses the chat hook, not /answer
+    throw new TakaroUserError('This is a Reaction Race! Type the token in chat, not as a command.');
+  } else {
+    // Unknown game type — do nothing
+    await pog.pm('No active round you can answer via /answer right now.');
+    return;
+  }
+
+  if (!correct) {
+    // Silent drop — don't spam chat with "wrong answer"
+    return;
+  }
+
+  // Winner — award points first so a transient API failure doesn't leave the player
+  // with a cleared round but no points
+  const pointsMap = {
+    trivia: config.pointsTriviaWin,
+    scramble: config.pointsScrambleWin,
+    mathrace: config.pointsMathRaceWin,
+  };
+  const basePoints = pointsMap[game] ?? 40;
+
+  await recordPlay(gameServerId, moduleId, pog.playerId, game);
+  const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+    gameServerId, moduleId, pog, game, points: basePoints, config, playerName: player.name,
+  });
+
+  // Clear round AFTER awarding — if award fails, round stays active
+  await clearActiveRound(gameServerId, moduleId);
+
+  const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+  const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+  const capNote = cappedByDaily
+    ? ' Daily point cap reached — no points awarded.'
+    : clippedByDaily
+      ? ` Daily cap clipped reward to ${actualPoints} points.`
+      : '';
+
+  const emojiMap = { trivia: '❓', scramble: '🔤', mathrace: '➗' };
+  const emoji = emojiMap[game] ?? '🎮';
+
+  const winMsg = game === 'mathrace'
+    ? `${emoji} CORRECT! @${player.name} = ${round.answer}. +${actualPoints} points${boostNote}${currencyNote}.${capNote}`
+    : game === 'scramble'
+      ? `${emoji} CORRECT! @${player.name} unscrambled ${round.answer.toUpperCase()}. +${actualPoints} points${boostNote}${currencyNote}.${capNote}`
+      : `${emoji} CORRECT! @${player.name} wins. Answer: ${round.answer}. +${actualPoints} points${boostNote}${currencyNote}.${capNote}`;
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: winMsg,
+    opts: {},
+  });
+}
+
+await main();

--- a/modules/mini-games/src/commands/hangman/index.js
+++ b/modules/mini-games/src/commands/hangman/index.js
@@ -1,0 +1,140 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getVariable, setVariable, checkBanAndCap, awardPoints, recordPlay, getContentBank, todayUTC,
+} from './mini-games-helpers.js';
+
+function buildMaskedWord(word, lettersTried) {
+  // Non-alpha characters (hyphens, apostrophes, spaces, etc.) are always revealed —
+  // players can only guess single letters so non-alpha positions can never be guessed.
+  return word.split('').map(ch => {
+    if (!/^[a-z]$/.test(ch)) return ch; // always reveal non-alpha
+    return lettersTried.includes(ch) ? ch.toUpperCase() : '_';
+  }).join(' ');
+}
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+  const today = todayUTC();
+
+  const puzzle = await getVariable(gameServerId, moduleId, 'minigames_puzzle_today');
+  if (!puzzle || puzzle.date !== today || !puzzle.hangman) {
+    await pog.pm("🎪 Hangman: Today's puzzle isn't ready yet. Ask an admin to run rollover or wait for midnight.");
+    return;
+  }
+
+  const target = puzzle.hangman.toLowerCase();
+  const sessionKey = `minigames_session:${pog.playerId}:hangman`;
+  const session = await getVariable(gameServerId, moduleId, sessionKey) ?? {
+    lettersTried: [], wrongCount: 0, solved: false, completedAt: null,
+  };
+
+  // '__status__' is the sentinel defaultValue used when no letter/word is provided
+  const rawInput = args.letterOrWord ? args.letterOrWord.toLowerCase().trim() : null;
+  const input = (rawInput && rawInput !== '__status__') ? rawInput : null;
+  const masked = buildMaskedWord(target, session.lettersTried);
+
+  // No arg — status
+  if (!input) {
+    if (session.solved) {
+      await pog.pm(`🎪 Hangman: You SOLVED today's puzzle! Wrong guesses: ${session.wrongCount}/6.`);
+      return;
+    }
+    if (session.wrongCount >= 6) {
+      await pog.pm(`🎪 Hangman: Game over! The word was: ${target.toUpperCase()}.`);
+      return;
+    }
+    await pog.pm(`🎪 Hangman: ${masked} (wrong ${session.wrongCount}/6, tried: ${session.lettersTried.join(', ') || 'none'})`);
+    return;
+  }
+
+  // Already done?
+  if (session.solved) throw new TakaroUserError("🎪 You've already solved today's Hangman!");
+  if (session.wrongCount >= 6) throw new TakaroUserError("🎪 Game over! You've used all 6 wrong guesses.");
+
+  // Check ban/cap
+  await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+
+  if (input.length === 1) {
+    // Single letter guess
+    if (!/^[a-z]$/.test(input)) {
+      throw new TakaroUserError('🎪 Single letter guesses must be a-z.');
+    }
+    if (session.lettersTried.includes(input)) {
+      throw new TakaroUserError(`🎪 You already tried "${input.toUpperCase()}".`);
+    }
+
+    session.lettersTried.push(input);
+    const inWord = target.includes(input);
+
+    if (!inWord) {
+      session.wrongCount++;
+    }
+
+    const newMasked = buildMaskedWord(target, session.lettersTried);
+    const fullyRevealed = !newMasked.includes('_');
+
+    if (fullyRevealed) {
+      session.solved = true;
+      session.completedAt = new Date().toISOString();
+      await setVariable(gameServerId, moduleId, sessionKey, session);
+
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'hangman');
+      const rawPoints = Math.round(config.pointsHangmanBase * (7 - session.wrongCount) / 7);
+      const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+        gameServerId, moduleId, pog, game: 'hangman', points: rawPoints, config, playerName: player.name,
+      });
+      const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+      const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+      const capNote = cappedByDaily
+        ? ' Daily point cap reached — no points awarded.'
+        : clippedByDaily
+          ? ` Daily cap clipped reward to ${actualPoints} points.`
+          : '';
+      await pog.pm(`🎪 ${newMasked} — SOLVED! +${actualPoints} points${boostNote}${currencyNote}.${capNote} Wrong: ${session.wrongCount}/6.`);
+    } else if (session.wrongCount >= 6) {
+      await setVariable(gameServerId, moduleId, sessionKey, session);
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'hangman');
+      await pog.pm(`🎪 Game over! "${input.toUpperCase()}" not in word. The word was: ${target.toUpperCase()}.`);
+    } else {
+      await setVariable(gameServerId, moduleId, sessionKey, session);
+      const hint = inWord ? `"${input.toUpperCase()}" is in the word!` : `"${input.toUpperCase()}" is NOT in the word.`;
+      await pog.pm(`🎪 ${newMasked} — ${hint} (wrong ${session.wrongCount}/6)`);
+    }
+  } else {
+    // Full word guess
+    if (input === target) {
+      session.solved = true;
+      session.completedAt = new Date().toISOString();
+      await setVariable(gameServerId, moduleId, sessionKey, session);
+
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'hangman');
+      const rawPoints = Math.round(config.pointsHangmanBase * (7 - session.wrongCount) / 7);
+      const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+        gameServerId, moduleId, pog, game: 'hangman', points: rawPoints, config, playerName: player.name,
+      });
+      const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+      const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+      const capNote = cappedByDaily
+        ? ' Daily point cap reached — no points awarded.'
+        : clippedByDaily
+          ? ` Daily cap clipped reward to ${actualPoints} points.`
+          : '';
+      await pog.pm(`🎪 SOLVED! +${actualPoints} points${boostNote}${currencyNote}.${capNote}`);
+    } else {
+      // Wrong full-word guess = instant loss
+      session.wrongCount = 6;
+      await setVariable(gameServerId, moduleId, sessionKey, session);
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'hangman');
+      await pog.pm(`🎪 Wrong word guess! Game over. The word was: ${target.toUpperCase()}.`);
+    }
+  }
+}
+
+await main();

--- a/modules/mini-games/src/commands/hotcold/index.js
+++ b/modules/mini-games/src/commands/hotcold/index.js
@@ -1,0 +1,109 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getVariable, setVariable, checkBanAndCap, awardPoints, recordPlay, todayUTC,
+} from './mini-games-helpers.js';
+
+function warmthLabel(guess, prevGuess, secret) {
+  if (prevGuess === null || prevGuess === undefined) return 'Baseline';
+  const dist = Math.abs(secret - guess);
+  const prevDist = Math.abs(secret - prevGuess);
+  if (dist < prevDist) return '🔥 Warmer';
+  if (dist > prevDist) return '🧊 Colder';
+  return '😐 Same';
+}
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+  const today = todayUTC();
+
+  const puzzle = await getVariable(gameServerId, moduleId, 'minigames_puzzle_today');
+  if (!puzzle || puzzle.date !== today || puzzle.hotcold === undefined || puzzle.hotcold === null) {
+    await pog.pm("🌡️ Hot/Cold: Today's puzzle isn't ready yet.");
+    return;
+  }
+
+  const secret = puzzle.hotcold;
+  const sessionKey = `minigames_session:${pog.playerId}:hotcold`;
+  const session = await getVariable(gameServerId, moduleId, sessionKey) ?? { guesses: [], solved: false, completedAt: null };
+
+  const rawNum = args.number;
+  // defaultValue "0" is used when no arg is provided; treat 0 as "no guess"
+  const hasGuess = rawNum !== null && rawNum !== undefined && rawNum !== 0 && rawNum !== '0';
+
+  // No arg — status
+  if (!hasGuess) {
+    if (session.solved) {
+      await pog.pm(`🌡️ Hot/Cold: You SOLVED today's puzzle in ${session.guesses.length} guess(es)!`);
+      return;
+    }
+    if (session.guesses.length === 0) {
+      await pog.pm('🌡️ Hot/Cold: No guesses yet. Use /hotcold <number 1-1000>!');
+      return;
+    }
+    if (session.guesses.length >= 8) {
+      await pog.pm(`🌡️ Hot/Cold: Game over! You used all 8 guesses. The secret was ${secret}.`);
+      return;
+    }
+    const trail = session.guesses.map((g, i) => {
+      const prev = i > 0 ? session.guesses[i - 1] : null;
+      return `  ${i + 1}. ${g} — ${warmthLabel(g, prev, secret)}`;
+    }).join('\n');
+    await pog.pm(`🌡️ Hot/Cold: ${8 - session.guesses.length} guesses left.\n${trail}\nUse /hotcold <number> to continue.`);
+    return;
+  }
+
+  if (session.solved) throw new TakaroUserError("🌡️ You've already solved today's Hot/Cold!");
+  if (session.guesses.length >= 8) throw new TakaroUserError(`🌡️ Game over! No guesses left. The secret was ${secret}.`);
+
+  const guess = Math.floor(Number(rawNum));
+  if (!Number.isFinite(guess) || guess < 1 || guess > 1000) {
+    throw new TakaroUserError('🌡️ Guess must be a whole number between 1 and 1000.');
+  }
+
+  await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+
+  const prevGuess = session.guesses.length > 0 ? session.guesses[session.guesses.length - 1] : null;
+  session.guesses.push(guess);
+  const guessNum = session.guesses.length;
+
+  if (guess === secret) {
+    session.solved = true;
+    session.completedAt = new Date().toISOString();
+    await setVariable(gameServerId, moduleId, sessionKey, session);
+
+    await recordPlay(gameServerId, moduleId, pog.playerId, 'hotcold');
+    const rawPoints = Math.round(config.pointsHotColdBase * (9 - guessNum) / 8);
+    const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+      gameServerId, moduleId, pog, game: 'hotcold', points: rawPoints, config, playerName: player.name,
+    });
+    const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+    const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+    const capNote = cappedByDaily
+      ? ' Daily point cap reached — no points awarded.'
+      : clippedByDaily
+        ? ` Daily cap clipped reward to ${actualPoints} points.`
+        : '';
+    await pog.pm(`🌡️ SOLVED in ${guessNum}! The secret was ${secret}. +${actualPoints} points${boostNote}${currencyNote}.${capNote}`);
+  } else {
+    await setVariable(gameServerId, moduleId, sessionKey, session);
+    const direction = guess < secret ? '⬆️ Higher' : '⬇️ Lower';
+    const warmth = warmthLabel(guess, prevGuess, secret);
+    const remaining = 8 - guessNum;
+
+    if (remaining === 0) {
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'hotcold');
+      await pog.pm(`🌡️ ${direction}. ${warmth}. No guesses left! The secret was ${secret}.`);
+    } else {
+      await pog.pm(`🌡️ ${direction}. ${warmth}. (${remaining} left)`);
+    }
+  }
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigames/index.js
+++ b/modules/mini-games/src/commands/minigames/index.js
@@ -1,0 +1,48 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+
+async function main() {
+  const { pog, arguments: args } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  // 'all' is the defaultValue used when no game arg is provided
+  const rawGame = args.game ? args.game.toLowerCase().trim() : null;
+  const game = (rawGame && rawGame !== 'all') ? rawGame : null;
+
+  const gameHelp = {
+    wordle: '🟩 Wordle: Guess the daily 5-letter word in 6 tries. /wordle <guess> or /wordle to check status.',
+    hangman: '🎪 Hangman: Guess the daily word letter by letter (6 wrong max). /hangman <letter|word> or /hangman for status.',
+    hotcold: '🌡️ Hot/Cold: Guess the secret number 1-1000 in 8 tries. /hotcold <number> or /hotcold for status.',
+    trivia: '❓ Trivia: Live rounds — first to /answer <answer> wins!',
+    scramble: '🔤 Scramble: Live rounds — unscramble the word. /answer <word>',
+    mathrace: '➗ Math race: Live rounds — solve the equation. /answer <number>',
+    reactionrace: '⚡ Reaction race: Live rounds — type the token in chat to win!',
+    answer: '📣 /answer <response> — Answer the currently active live round.',
+    stats: '📊 /minigamestats [player] — View stats. /minigamestop <points|wordle|hangman|streak> — Leaderboards.',
+    puzzle: '🗓️ /puzzle — Today\'s puzzle status and time until midnight rollover.',
+  };
+
+  if (game) {
+    const help = gameHelp[game];
+    if (!help) {
+      throw new TakaroUserError(`Unknown game: "${args.game}". Valid games: wordle, hangman, hotcold, trivia, scramble, mathrace, reactionrace`);
+    }
+    await pog.pm(help);
+    return;
+  }
+
+  const lines = [
+    '🎮 miniGames — Unified mini-game module',
+    '─────────────────────────────────────',
+    '📅 Daily puzzles: /wordle  /hangman  /hotcold',
+    '⚡ Live rounds: /answer <response>',
+    '📊 Stats: /minigamestats  /minigamestop <points|wordle|hangman|streak>',
+    '🗓️ Status: /puzzle',
+    'Type /minigames <game> for per-game rules (e.g. /minigames wordle)',
+  ];
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesban/index.js
+++ b/modules/mini-games/src/commands/minigamesban/index.js
@@ -1,0 +1,40 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { setVariable, findPlayerByGameId } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+
+  if (!args.player) {
+    throw new TakaroUserError('Usage: /minigamesban <gameId> [hours]');
+  }
+
+  const target = await findPlayerByGameId(gameServerId, args.player);
+  if (!target) {
+    throw new TakaroUserError(`Player with gameId "${args.player}" not found.`);
+  }
+
+  const banData = {};
+  let description = 'permanently';
+
+  // hours defaultValue is "0" — treat 0 as "permanent" (no expiry)
+  const hoursNum = Number(args.hours ?? 0);
+  if (hoursNum > 0) {
+    if (!isFinite(hoursNum)) {
+      throw new TakaroUserError('Hours must be a positive number.');
+    }
+    const expiresAt = new Date(Date.now() + hoursNum * 3600 * 1000).toISOString();
+    banData.expiresAt = expiresAt;
+    description = `for ${hoursNum}h (until ${new Date(expiresAt).toUTCString()})`;
+  }
+
+  await setVariable(gameServerId, moduleId, `minigames_ban:${target.id}`, banData);
+  await pog.pm(`🔨 ${target.name} has been banned from mini-games ${description}.`);
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesfirenow/index.js
+++ b/modules/mini-games/src/commands/minigamesfirenow/index.js
@@ -1,0 +1,37 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  setVariable, getActiveRound, buildAndFireLiveRound,
+} from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+  const forcedGame = args.game ? args.game.toLowerCase() : null;
+
+  // Check if a round is already active
+  const existing = await getActiveRound(gameServerId, moduleId);
+  if (existing) {
+    throw new TakaroUserError('A live round is already active! Use /minigamesskiproundnow to cancel it first.');
+  }
+
+  const round = await buildAndFireLiveRound(gameServerId, moduleId, config, forcedGame);
+  if (!round) {
+    // buildAndFireLiveRound already sent an admin chat warning for empty banks
+    // (deduped per-day per-key). Send a personal PM so this admin always gets
+    // feedback without re-broadcasting a global warning.
+    const gameLabel = forcedGame ? ` game=${forcedGame}` : '';
+    await pog.pm(`⚠️ miniGames: could not fire${gameLabel} — content bank may be empty or all games disabled. Check the Variables tab.`);
+    return;
+  }
+
+  await setVariable(gameServerId, moduleId, 'minigames_last_round_firedAt', new Date().toISOString());
+  console.log(`miniGames minigamesfirenow: fired game=${round.game}`);
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesreport/index.js
+++ b/modules/mini-games/src/commands/minigamesreport/index.js
@@ -1,0 +1,63 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { searchVariablesByKeyPrefix } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+
+  // Aggregate all player stats (lifetime — no date filter supported)
+  const allStatVars = await searchVariablesByKeyPrefix(gameServerId, moduleId, 'minigames_stats:');
+  const allStats = allStatVars.map(v => {
+    try { return JSON.parse(v.value); } catch { return null; }
+  }).filter(Boolean);
+
+  const totalPlayers = allStats.length;
+  const totalPoints = allStats.reduce((s, st) => s + (st.totalPoints ?? 0), 0);
+  const totalGamesPlayed = allStats.reduce((s, st) => s + (st.gamesPlayed ?? 0), 0);
+
+  // Per-game breakdown
+  const gameNames = ['wordle', 'hangman', 'hotcold', 'trivia', 'scramble', 'mathrace', 'reactionrace'];
+  const perGameTotals = {};
+  for (const g of gameNames) {
+    perGameTotals[g] = { points: 0, plays: 0, wins: 0 };
+    for (const st of allStats) {
+      const pg = st.perGame?.[g];
+      if (pg) {
+        perGameTotals[g].points += pg.points ?? 0;
+        perGameTotals[g].plays += pg.plays ?? 0;
+        perGameTotals[g].wins += pg.wins ?? 0;
+      }
+    }
+  }
+
+  // Top 5 by total points (using player ID as name; leaderboard cache has resolved names)
+  const sorted = allStats
+    .map((st, i) => ({ name: allStatVars[i].key.replace('minigames_stats:', ''), points: st.totalPoints ?? 0 }))
+    .sort((a, b) => b.points - a.points)
+    .slice(0, 5);
+
+  const lines = [
+    `📋 miniGames Report (all-time lifetime stats)`,
+    `Players with stats: ${totalPlayers}`,
+    `Total points awarded: ${totalPoints}`,
+    `Total games played: ${totalGamesPlayed}`,
+    ``,
+    `Top 5 players:`,
+    ...sorted.map((p, i) => `  ${i + 1}. ${p.name}: ${p.points} pts`),
+    ``,
+    `Per-game breakdown:`,
+    ...gameNames.filter(g => perGameTotals[g].plays > 0).map(g => {
+      const pg = perGameTotals[g];
+      return `  ${g}: ${pg.plays} plays, ${pg.wins} wins, ${pg.points} pts`;
+    }),
+  ];
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesresetstats/index.js
+++ b/modules/mini-games/src/commands/minigamesresetstats/index.js
@@ -1,0 +1,26 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { deleteVariable, findPlayerByGameId } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+
+  if (!args.player) {
+    throw new TakaroUserError('Usage: /minigamesresetstats <gameId>');
+  }
+
+  const target = await findPlayerByGameId(gameServerId, args.player);
+  if (!target) {
+    throw new TakaroUserError(`Player with gameId "${args.player}" not found.`);
+  }
+
+  await deleteVariable(gameServerId, moduleId, `minigames_stats:${target.id}`);
+  await pog.pm(`✅ Stats for ${target.name} have been reset.`);
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesskiproundnow/index.js
+++ b/modules/mini-games/src/commands/minigamesskiproundnow/index.js
@@ -1,0 +1,29 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { getActiveRound, clearActiveRound } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const round = await getActiveRound(gameServerId, moduleId);
+
+  if (!round) {
+    throw new TakaroUserError('There is no active live round to cancel.');
+  }
+
+  await clearActiveRound(gameServerId, moduleId);
+
+  const emojiMap = { trivia: '❓', scramble: '🔤', mathrace: '➗', reactionrace: '⚡' };
+  const emoji = emojiMap[round.game] ?? '🎮';
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `${emoji} Round cancelled by admin. The answer was: ${round.answer}.`,
+    opts: {},
+  });
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamestats/index.js
+++ b/modules/mini-games/src/commands/minigamestats/index.js
@@ -1,0 +1,56 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { getVariable, findPlayerByName, todayUTC } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  let targetPlayerId = pog.playerId;
+  let targetName = player.name;
+
+  // 'self' is the defaultValue used when no player arg is provided (show own stats)
+  if (args.player && args.player !== 'self') {
+    const found = await findPlayerByName(gameServerId, args.player);
+    if (!found) {
+      throw new TakaroUserError(`Player "${args.player}" not found.`);
+    }
+    targetPlayerId = found.id;
+    targetName = found.name;
+  }
+
+  const stats = await getVariable(gameServerId, moduleId, `minigames_stats:${targetPlayerId}`);
+  const today = todayUTC();
+  const window = await getVariable(gameServerId, moduleId, `minigames_window:${targetPlayerId}:${today}`);
+
+  if (!stats) {
+    await pog.pm(`📊 ${targetName} has no mini-games stats yet. Play some games!`);
+    return;
+  }
+
+  const perGame = stats.perGame ?? {};
+  const lines = [
+    `📊 Stats for ${targetName}`,
+    `─────────────────────────────────────`,
+    `Total points: ${stats.totalPoints ?? 0}  |  Games played: ${stats.gamesPlayed ?? 0}`,
+    `Today's points: ${window?.earned ?? 0}`,
+    `Best score: ${stats.biggestScore?.points ?? 0} pts (${stats.biggestScore?.game ?? 'n/a'})`,
+    `Wordle streak: ${stats.streaks?.wordle?.current ?? 0} (best: ${stats.streaks?.wordle?.best ?? 0})`,
+    `─────────────────────────────────────`,
+  ];
+
+  const gameOrder = ['wordle', 'hangman', 'hotcold', 'trivia', 'scramble', 'mathrace', 'reactionrace'];
+  for (const g of gameOrder) {
+    const gStats = perGame[g];
+    if (gStats) {
+      lines.push(`${g}: ${gStats.wins ?? 0}W / ${gStats.plays ?? 0}P — ${gStats.points ?? 0} pts`);
+    }
+  }
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamestop/index.js
+++ b/modules/mini-games/src/commands/minigamestop/index.js
@@ -1,0 +1,55 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { getVariable } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const category = args.category ? args.category.toLowerCase() : null;
+
+  if (!category || !['points', 'wordle', 'hangman', 'streak'].includes(category)) {
+    throw new TakaroUserError('Usage: /minigamestop <points|wordle|hangman|streak>');
+  }
+
+  const cache = await getVariable(gameServerId, moduleId, 'minigames_leaderboard_cache');
+
+  if (!cache) {
+    await pog.pm('📊 Leaderboard not yet generated. Wait a few minutes for the cache to refresh.');
+    return;
+  }
+
+  const keyMap = {
+    points: 'topPoints',
+    wordle: 'topWordle',
+    hangman: 'topHangman',
+    streak: 'topStreak',
+  };
+
+  const board = cache[keyMap[category]] ?? [];
+
+  if (board.length === 0) {
+    await pog.pm(`📊 No entries in the ${category} leaderboard yet.`);
+    return;
+  }
+
+  const labelMap = {
+    points: '🏆 Top Players by Total Points',
+    wordle: '🟩 Top Wordle Players',
+    hangman: '🎪 Top Hangman Players',
+    streak: '🔥 Top Wordle Streaks',
+  };
+
+  const lines = [labelMap[category]];
+  board.forEach((entry, i) => {
+    lines.push(`  ${i + 1}. ${entry.name}: ${entry.value}`);
+  });
+  lines.push(`Refreshed: ${cache.refreshedAt ?? 'unknown'}`);
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/mini-games/src/commands/minigamesunban/index.js
+++ b/modules/mini-games/src/commands/minigamesunban/index.js
@@ -1,0 +1,26 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { deleteVariable, findPlayerByGameId } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_MANAGE')) {
+    throw new TakaroUserError('You do not have permission to manage mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+
+  if (!args.player) {
+    throw new TakaroUserError('Usage: /minigamesunban <gameId>');
+  }
+
+  const target = await findPlayerByGameId(gameServerId, args.player);
+  if (!target) {
+    throw new TakaroUserError(`Player with gameId "${args.player}" not found.`);
+  }
+
+  await deleteVariable(gameServerId, moduleId, `minigames_ban:${target.id}`);
+  await pog.pm(`✅ ${target.name} has been unbanned from mini-games.`);
+}
+
+await main();

--- a/modules/mini-games/src/commands/puzzle/index.js
+++ b/modules/mini-games/src/commands/puzzle/index.js
@@ -1,0 +1,50 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import { getVariable, todayUTC } from './mini-games-helpers.js';
+
+async function main() {
+  const { pog, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const today = todayUTC();
+  const puzzle = await getVariable(gameServerId, moduleId, 'minigames_puzzle_today');
+
+  const now = new Date();
+  const midnight = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1));
+  const msLeft = midnight - now;
+  const hoursLeft = Math.floor(msLeft / 3600000);
+  const minsLeft = Math.floor((msLeft % 3600000) / 60000);
+
+  const [wordleSession, hangmanSession, hotcoldSession] = await Promise.all([
+    getVariable(gameServerId, moduleId, `minigames_session:${pog.playerId}:wordle`),
+    getVariable(gameServerId, moduleId, `minigames_session:${pog.playerId}:hangman`),
+    getVariable(gameServerId, moduleId, `minigames_session:${pog.playerId}:hotcold`),
+  ]);
+
+  function statusLabel(session, available, maxGuesses) {
+    if (!available) return '❌ not available';
+    if (!session) return '🔵 not started';
+    if (session.solved) return '✅ solved';
+    if (session.guesses?.length >= maxGuesses || session.wrongCount >= maxGuesses) return '❌ failed';
+    return '🔄 in progress';
+  }
+
+  const wordleAvail = puzzle && puzzle.date === today && !!puzzle.wordle;
+  const hangmanAvail = puzzle && puzzle.date === today && !!puzzle.hangman;
+  const hotcoldAvail = puzzle && puzzle.date === today && puzzle.hotcold !== undefined && puzzle.hotcold !== null;
+
+  const lines = [
+    `🗓️ Today's Puzzles (${today})`,
+    `  🟩 Wordle:   ${statusLabel(wordleSession, wordleAvail, 6)}`,
+    `  🎪 Hangman:  ${statusLabel(hangmanSession, hangmanAvail, 6)}`,
+    `  🌡️ Hot/Cold: ${statusLabel(hotcoldSession, hotcoldAvail, 8)}`,
+    `⏰ Rollover in: ${hoursLeft}h ${minsLeft}m`,
+  ];
+
+  await pog.pm(lines.join('\n'));
+}
+
+await main();

--- a/modules/mini-games/src/commands/wordle/index.js
+++ b/modules/mini-games/src/commands/wordle/index.js
@@ -1,0 +1,147 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getVariable, setVariable, checkBanAndCap, awardPoints, recordPlay, updateWordleStreak,
+  getContentBank, todayUTC,
+} from './mini-games-helpers.js';
+
+function computeWordleFeedback(guess, target) {
+  // Standard Wordle feedback: 🟩 = right spot, 🟨 = wrong spot, ⬜ = not in word
+  const result = Array(5).fill('⬜');
+  const targetArr = target.split('');
+  const guessArr = guess.split('');
+  const targetUsed = Array(5).fill(false);
+  const guessUsed = Array(5).fill(false);
+
+  // First pass: right spot
+  for (let i = 0; i < 5; i++) {
+    if (guessArr[i] === targetArr[i]) {
+      result[i] = '🟩';
+      targetUsed[i] = true;
+      guessUsed[i] = true;
+    }
+  }
+  // Second pass: wrong spot
+  for (let i = 0; i < 5; i++) {
+    if (guessUsed[i]) continue;
+    for (let j = 0; j < 5; j++) {
+      if (targetUsed[j]) continue;
+      if (guessArr[i] === targetArr[j]) {
+        result[i] = '🟨';
+        targetUsed[j] = true;
+        break;
+      }
+    }
+  }
+  return result.join('');
+}
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    throw new TakaroUserError('You do not have permission to use mini-games.');
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  // Get today's puzzle
+  const today = todayUTC();
+  const puzzle = await getVariable(gameServerId, moduleId, 'minigames_puzzle_today');
+
+  if (!puzzle || puzzle.date !== today || !puzzle.wordle) {
+    await pog.pm("🟩 Wordle: Today's puzzle isn't set up yet. Ask an admin to run /minigamesfirenow or wait for midnight rollover.");
+    return;
+  }
+
+  const target = puzzle.wordle.toLowerCase();
+  const sessionKey = `minigames_session:${pog.playerId}:wordle`;
+  const session = await getVariable(gameServerId, moduleId, sessionKey) ?? { guesses: [], solved: false, completedAt: null };
+
+  // '__status__' is the sentinel defaultValue used when no guess is provided
+  const rawGuess = args.guess ? args.guess.toLowerCase().trim() : null;
+  const guess = (rawGuess && rawGuess !== '__status__') ? rawGuess : null;
+
+  // No arg — show status
+  if (!guess) {
+    if (session.solved) {
+      await pog.pm(`🟩 Wordle: You SOLVED today's puzzle in ${session.guesses.length}/6! Well done.`);
+      return;
+    }
+    if (session.guesses.length === 0) {
+      await pog.pm('🟩 Wordle: No guesses yet. Use /wordle <5-letter-word> to guess!');
+      return;
+    }
+    const history = session.guesses.map((g, i) => `  ${i + 1}. ${g.toUpperCase()} ${computeWordleFeedback(g, target)}`).join('\n');
+    await pog.pm(`🟩 Wordle: ${session.guesses.length}/6 guesses used.\n${history}\nUse /wordle <guess> to continue.`);
+    return;
+  }
+
+  // Validate guess
+  if (session.solved) {
+    throw new TakaroUserError("🟩 You've already solved today's Wordle!");
+  }
+  if (session.guesses.length >= 6) {
+    throw new TakaroUserError("🟩 You've used all 6 guesses. The word was: " + target.toUpperCase());
+  }
+
+  // Check ban (throws if banned; no longer throws on cap-exhausted)
+  await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+
+  if (!/^[a-z]{5}$/.test(guess)) {
+    throw new TakaroUserError('🟩 Wordle guess must be exactly 5 letters (a-z only).');
+  }
+
+  // Validate word is in bank
+  const bank = await getContentBank(gameServerId, moduleId, 'minigames_content_wordle', { words: [] });
+  const validWords = (bank.words ?? []).map(w => w.toLowerCase()).filter(w => /^[a-z]{5}$/.test(w));
+  if (!validWords.includes(guess)) {
+    throw new TakaroUserError(`🟩 "${guess.toUpperCase()}" is not in the word list. Try a different word.`);
+  }
+
+  // Apply guess
+  session.guesses.push(guess);
+  const feedback = computeWordleFeedback(guess, target);
+  const guessNum = session.guesses.length;
+
+  if (guess === target) {
+    session.solved = true;
+    session.completedAt = new Date().toISOString();
+    await setVariable(gameServerId, moduleId, sessionKey, session);
+
+    // Record play attempt (session completed — win)
+    await recordPlay(gameServerId, moduleId, pog.playerId, 'wordle');
+
+    const rawPoints = Math.round(config.pointsWordleBase * (7 - guessNum) / 6);
+    const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+      gameServerId, moduleId, pog, game: 'wordle', points: rawPoints, config, playerName: player.name,
+    });
+    await updateWordleStreak(gameServerId, moduleId, pog.playerId, true);
+
+    const statsKey = `minigames_stats:${pog.playerId}`;
+    const stats = await getVariable(gameServerId, moduleId, statsKey);
+    const streak = stats?.streaks?.wordle?.current ?? 1;
+    const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+    const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+    const capNote = cappedByDaily
+      ? ' Daily point cap reached — no points awarded.'
+      : clippedByDaily
+        ? ` Daily cap clipped reward to ${actualPoints} points.`
+        : '';
+    await pog.pm(`🟩 ${feedback} SOLVED in ${guessNum}! +${actualPoints} points${boostNote}${currencyNote}.${capNote} Streak: ${streak} 🔥`);
+  } else {
+    await setVariable(gameServerId, moduleId, sessionKey, session);
+    const remaining = 6 - guessNum;
+
+    if (remaining === 0) {
+      // Record play attempt (session completed — loss)
+      await recordPlay(gameServerId, moduleId, pog.playerId, 'wordle');
+      await updateWordleStreak(gameServerId, moduleId, pog.playerId, false);
+      await pog.pm(`🟩 ${feedback} No guesses left! The word was: ${target.toUpperCase()}. Better luck tomorrow!`);
+    } else {
+      await pog.pm(`🟩 ${feedback} (${remaining}/6 left)`);
+    }
+  }
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/close-live-round/index.js
+++ b/modules/mini-games/src/cronjobs/close-live-round/index.js
@@ -1,0 +1,31 @@
+import { data, takaro } from '@takaro/helpers';
+import { getActiveRound, clearActiveRound } from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  const round = await getActiveRound(gameServerId, moduleId);
+  if (!round) return;
+
+  if (!round.expiresAt || new Date(round.expiresAt) > new Date()) return;
+
+  // Round expired with no winner
+  await clearActiveRound(gameServerId, moduleId);
+
+  const emojiMap = { trivia: '❓', scramble: '🔤', mathrace: '➗', reactionrace: '⚡' };
+  const emoji = emojiMap[round.game] ?? '🎮';
+
+  const answerDisplay = Array.isArray(round.answer)
+    ? round.answer.join(', ')
+    : String(round.answer);
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `${emoji} Time's up! Nobody got it. The answer was: ${answerDisplay}.`,
+    opts: {},
+  });
+
+  console.log(`miniGames closeLiveRound: closed expired round game=${round.game}, answer=${answerDisplay}`);
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/expire-bans/index.js
+++ b/modules/mini-games/src/cronjobs/expire-bans/index.js
@@ -1,0 +1,24 @@
+import { data, takaro } from '@takaro/helpers';
+import { searchVariablesByKeyPrefix } from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  const banVars = await searchVariablesByKeyPrefix(gameServerId, moduleId, 'minigames_ban:');
+  const now = new Date();
+  let deleted = 0;
+
+  for (const v of banVars) {
+    let banData;
+    try { banData = JSON.parse(v.value); } catch { continue; }
+    if (banData.expiresAt && new Date(banData.expiresAt) < now) {
+      await takaro.variable.variableControllerDelete(v.id);
+      deleted++;
+    }
+  }
+
+  console.log(`miniGames expireBans: removed ${deleted} expired ban(s)`);
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/expire-windows/index.js
+++ b/modules/mini-games/src/cronjobs/expire-windows/index.js
@@ -1,0 +1,25 @@
+import { data, takaro } from '@takaro/helpers';
+import { searchVariablesByKeyPrefix, todayUTC } from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  const today = todayUTC();
+  const windowVars = await searchVariablesByKeyPrefix(gameServerId, moduleId, 'minigames_window:');
+
+  let deleted = 0;
+  for (const v of windowVars) {
+    // Key format: minigames_window:{playerId}:{YYYY-MM-DD}
+    const parts = v.key.split(':');
+    const dateStr = parts[parts.length - 1];
+    if (dateStr && dateStr < today) {
+      await takaro.variable.variableControllerDelete(v.id);
+      deleted++;
+    }
+  }
+
+  console.log(`miniGames expireWindows: deleted ${deleted} window variables (keeping today=${today})`);
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/fire-live-round/index.js
+++ b/modules/mini-games/src/cronjobs/fire-live-round/index.js
@@ -1,0 +1,51 @@
+import { data, takaro } from '@takaro/helpers';
+import {
+  getVariable, setVariable, getActiveRound, buildAndFireLiveRound,
+} from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  // Check interval elapsed
+  const intervalMinutes = config.liveRoundIntervalMinutes ?? 30;
+  const lastFiredAt = await getVariable(gameServerId, moduleId, 'minigames_last_round_firedAt');
+  if (lastFiredAt) {
+    const elapsed = (Date.now() - new Date(lastFiredAt).getTime()) / 60000;
+    if (elapsed < intervalMinutes) {
+      console.log(`miniGames fireLiveRound: ${elapsed.toFixed(1)}min elapsed < ${intervalMinutes}min interval, skipping`);
+      return;
+    }
+  }
+
+  // Check player count
+  const minPlayers = config.minPlayersForLiveRound ?? 2;
+  const playersRes = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+    filters: { gameServerId: [gameServerId], online: [true] },
+    limit: 100,
+  });
+  const onlineCount = playersRes.data.data.length;
+  if (onlineCount < minPlayers) {
+    console.log(`miniGames fireLiveRound: only ${onlineCount} players online, need ${minPlayers}, skipping`);
+    return;
+  }
+
+  // Check no active round
+  const existing = await getActiveRound(gameServerId, moduleId);
+  if (existing) {
+    console.log('miniGames fireLiveRound: round already active, skipping');
+    return;
+  }
+
+  const round = await buildAndFireLiveRound(gameServerId, moduleId, config, null);
+  if (!round) {
+    console.log('miniGames fireLiveRound: no game could be fired (empty bank or all disabled)');
+    return;
+  }
+
+  await setVariable(gameServerId, moduleId, 'minigames_last_round_firedAt', new Date().toISOString());
+  console.log(`miniGames fireLiveRound: fired game=${round.game}, expiresAt=${round.expiresAt}`);
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/refresh-leaderboards/index.js
+++ b/modules/mini-games/src/cronjobs/refresh-leaderboards/index.js
@@ -1,0 +1,81 @@
+import { data, takaro } from '@takaro/helpers';
+import { searchVariablesByKeyPrefix, setVariable } from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+
+  const allStatVars = await searchVariablesByKeyPrefix(gameServerId, moduleId, 'minigames_stats:');
+
+  const entries = allStatVars.map(v => {
+    let stats;
+    try { stats = JSON.parse(v.value); } catch { return null; }
+    const playerId = v.key.replace('minigames_stats:', '');
+    return { playerId, stats };
+  }).filter(Boolean);
+
+  // Batch-resolve player names from Takaro — chunked into pages of 100 to stay within API limits
+  const nameMap = {};
+  const playerIds = entries.map(e => e.playerId);
+  const CHUNK_SIZE = 100;
+  if (playerIds.length > 0) {
+    const chunks = [];
+    for (let i = 0; i < playerIds.length; i += CHUNK_SIZE) {
+      chunks.push(playerIds.slice(i, i + CHUNK_SIZE));
+    }
+    const results = await Promise.allSettled(chunks.map(chunk =>
+      takaro.player.playerControllerSearch({
+        filters: { id: chunk },
+        limit: chunk.length,
+      })
+    ));
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        for (const p of result.value.data.data) {
+          nameMap[p.id] = p.name ?? p.id;
+        }
+      } else {
+        console.log(`miniGames refreshLeaderboards: chunk ${i} name lookup failed (${result.reason?.message ?? result.reason}); ${chunks[i].length} players will fall back to playerIds`);
+      }
+    }
+  }
+  // Fill in any missing entries with their playerId as display name
+  for (const e of entries) {
+    if (!nameMap[e.playerId]) nameMap[e.playerId] = e.playerId;
+  }
+
+  function topN(arr, n) { return arr.slice(0, n); }
+
+  const byPoints = entries
+    .map(e => ({ name: nameMap[e.playerId] ?? e.playerId, value: e.stats.totalPoints ?? 0 }))
+    .sort((a, b) => b.value - a.value);
+
+  const byWordle = entries
+    .map(e => ({ name: nameMap[e.playerId] ?? e.playerId, value: e.stats.perGame?.wordle?.wins ?? 0 }))
+    .filter(e => e.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  const byHangman = entries
+    .map(e => ({ name: nameMap[e.playerId] ?? e.playerId, value: e.stats.perGame?.hangman?.wins ?? 0 }))
+    .filter(e => e.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  const byStreak = entries
+    .map(e => ({ name: nameMap[e.playerId] ?? e.playerId, value: e.stats.streaks?.wordle?.best ?? 0 }))
+    .filter(e => e.value > 0)
+    .sort((a, b) => b.value - a.value);
+
+  const cache = {
+    topPoints: topN(byPoints, 10),
+    topWordle: topN(byWordle, 10),
+    topHangman: topN(byHangman, 10),
+    topStreak: topN(byStreak, 10),
+    refreshedAt: new Date().toISOString(),
+  };
+
+  await setVariable(gameServerId, moduleId, 'minigames_leaderboard_cache', cache);
+  console.log(`miniGames refreshLeaderboards: updated, ${entries.length} players, top points = ${cache.topPoints[0]?.value ?? 0}`);
+}
+
+await main();

--- a/modules/mini-games/src/cronjobs/rollover-daily-puzzles/index.js
+++ b/modules/mini-games/src/cronjobs/rollover-daily-puzzles/index.js
@@ -1,0 +1,73 @@
+import { data, takaro } from '@takaro/helpers';
+import {
+  getVariable, setVariable, deleteVariable, searchVariablesByKeyPrefix,
+  getContentBank, warnAdminEmptyBank, todayUTC,
+} from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+  const today = todayUTC();
+  const missingBanks = [];
+
+  let wordleWord = null;
+  let hangmanWord = null;
+  let hotcoldSecret = null;
+
+  // Wordle
+  if (config.games?.wordle !== false) {
+    const bank = await getContentBank(gameServerId, moduleId, 'minigames_content_wordle', { words: [] });
+    const words = (bank.words ?? []).map(w => w.toLowerCase()).filter(w => /^[a-z]{5}$/.test(w));
+    if (words.length === 0) {
+      missingBanks.push('minigames_content_wordle');
+    } else {
+      wordleWord = words[Math.floor(Math.random() * words.length)];
+    }
+  }
+
+  // Hangman — filter to a-z only (no hyphens, apostrophes, etc.) to ensure
+  // letter guesses can always reveal every character
+  if (config.games?.hangman !== false) {
+    const bank = await getContentBank(gameServerId, moduleId, 'minigames_content_wordlist', { words: [] });
+    const words = (bank.words ?? []).filter(w => /^[a-z]+$/.test(w) && w.length >= 3);
+    if (words.length === 0) {
+      missingBanks.push('minigames_content_wordlist');
+    } else {
+      hangmanWord = words[Math.floor(Math.random() * words.length)].toLowerCase();
+    }
+  }
+
+  // Hot/Cold
+  if (config.games?.hotcold !== false) {
+    hotcoldSecret = Math.floor(Math.random() * 1000) + 1;
+  }
+
+  // Warn admin about empty banks
+  await warnAdminEmptyBank(gameServerId, moduleId, missingBanks);
+
+  // Write today's puzzle
+  const puzzle = { date: today };
+  if (wordleWord) puzzle.wordle = wordleWord;
+  if (hangmanWord) puzzle.hangman = hangmanWord;
+  if (hotcoldSecret !== null) puzzle.hotcold = hotcoldSecret;
+  await setVariable(gameServerId, moduleId, 'minigames_puzzle_today', puzzle);
+  console.log(`miniGames rolloverDailyPuzzles: date=${today}, wordle=${wordleWord ?? 'N/A'}, hangman=${hangmanWord ?? 'N/A'}, hotcold=${hotcoldSecret ?? 'N/A'}`);
+
+  // Clear yesterday's player sessions (all session keys for wordle/hangman/hotcold)
+  const sessionVars = await searchVariablesByKeyPrefix(gameServerId, moduleId, 'minigames_session:');
+  let cleared = 0;
+  for (const v of sessionVars) {
+    await takaro.variable.variableControllerDelete(v.id);
+    cleared++;
+  }
+  console.log(`miniGames rolloverDailyPuzzles: cleared ${cleared} player session variables`);
+
+  // Reset admin warned flag for new day
+  const warnVar = await getVariable(gameServerId, moduleId, 'minigames_admin_warned_empty_bank');
+  if (warnVar && warnVar.date !== today) {
+    await deleteVariable(gameServerId, moduleId, 'minigames_admin_warned_empty_bank');
+  }
+}
+
+await main();

--- a/modules/mini-games/src/functions/mini-games-helpers.js
+++ b/modules/mini-games/src/functions/mini-games-helpers.js
@@ -1,0 +1,584 @@
+import { takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+
+// ─── OpenTDB category map (lifted from 7dtd_triviaTime) ───────────────────────
+export const OPENTDB_CATEGORIES = {
+  general_knowledge: 9, books: 10, film: 11, music: 12, musicals_theatres: 13,
+  television: 14, video_games: 15, board_games: 16, science_nature: 17,
+  computers: 18, mathematics: 19, mythology: 20, sports: 21, geography: 22,
+  history: 23, politics: 24, art: 25, celebrities: 26, animals: 27,
+  vehicles: 28, comics: 29, gadgets: 30, anime_manga: 31, cartoon_animations: 32
+};
+
+// ─── HTML entity decoder ──────────────────────────────────────────────────────
+export function decodeHtmlEntities(s) {
+  if (!s) return s;
+  return s
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#039;/g, "'")
+    .replace(/&apos;/g, "'")
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&eacute;/g, 'é')
+    .replace(/&egrave;/g, 'è')
+    .replace(/&ecirc;/g, 'ê')
+    .replace(/&agrave;/g, 'à')
+    .replace(/&ugrave;/g, 'ù')
+    .replace(/&uuml;/g, 'ü')
+    .replace(/&ouml;/g, 'ö')
+    .replace(/&auml;/g, 'ä')
+    .replace(/&ntilde;/g, 'ñ')
+    .replace(/&hellip;/g, '...')
+    .replace(/&mdash;/g, '—')
+    .replace(/&ndash;/g, '–')
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(parseInt(code, 10)));
+}
+
+// ─── Variable helpers ─────────────────────────────────────────────────────────
+
+export async function getVariable(gameServerId, moduleId, key) {
+  const res = await takaro.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  if (res.data.data.length === 0) return null;
+  try {
+    return JSON.parse(res.data.data[0].value);
+  } catch {
+    return res.data.data[0].value;
+  }
+}
+
+export async function setVariable(gameServerId, moduleId, key, value) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  const existing = await takaro.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  if (existing.data.data.length > 0) {
+    await takaro.variable.variableControllerUpdate(existing.data.data[0].id, { value: serialized });
+  } else {
+    await takaro.variable.variableControllerCreate({ key, value: serialized, gameServerId, moduleId });
+  }
+}
+
+export async function deleteVariable(gameServerId, moduleId, key) {
+  const existing = await takaro.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  if (existing.data.data.length > 0) {
+    await takaro.variable.variableControllerDelete(existing.data.data[0].id);
+  }
+}
+
+export async function searchVariablesByKeyPrefix(gameServerId, moduleId, prefix) {
+  // Takaro variable search doesn't support prefix; page through all and filter client-side.
+  const results = [];
+  let page = 0;
+  const limit = 100;
+  while (true) {
+    const res = await takaro.variable.variableControllerSearch({
+      filters: { gameServerId: [gameServerId], moduleId: [moduleId] },
+      page,
+      limit,
+      sortBy: 'key',
+      sortDirection: 'asc',
+    });
+    const batch = res.data.data;
+    for (const v of batch) {
+      if (v.key.startsWith(prefix)) results.push(v);
+    }
+    if (batch.length < limit) break;
+    page++;
+  }
+  return results;
+}
+
+// ─── Today's UTC date string ──────────────────────────────────────────────────
+export function todayUTC() {
+  return new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
+}
+
+// ─── Player lookup by name ────────────────────────────────────────────────────
+export async function findPlayerByName(gameServerId, name) {
+  // Search globally by name first
+  const res = await takaro.player.playerControllerSearch({
+    filters: { name: [name] },
+    limit: 5,
+  });
+  const matches = res.data.data.filter(p => p.name.toLowerCase() === name.toLowerCase());
+  if (matches.length === 0) return null;
+
+  // Verify the player is on the target gameServer to avoid cross-server name collisions
+  for (const player of matches) {
+    const pogRes = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [gameServerId], playerId: [player.id] },
+      limit: 1,
+    });
+    if (pogRes.data.data.length > 0) {
+      return player;
+    }
+  }
+  return null;
+}
+
+// ─── Player lookup by gameId (in-game identifier) ────────────────────────────
+export async function findPlayerByGameId(gameServerId, gameId) {
+  const res = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+    filters: { gameServerId: [gameServerId], gameId: [gameId] },
+    limit: 1,
+  });
+  if (res.data.data.length === 0) return null;
+  const pog = res.data.data[0];
+  // Fetch the player record for name and id
+  const playerRes = await takaro.player.playerControllerGetOne(pog.playerId);
+  return { id: pog.playerId, name: playerRes.data.data.name, pog };
+}
+
+export async function findPogByPlayerId(gameServerId, playerId) {
+  const res = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+    filters: { gameServerId: [gameServerId], playerId: [playerId] },
+    limit: 1,
+  });
+  if (res.data.data.length === 0) return null;
+  return res.data.data[0];
+}
+
+// ─── Scorer ───────────────────────────────────────────────────────────────────
+
+export async function checkBanAndCap(gameServerId, moduleId, playerId, config) {
+  // Check ban — always throws if banned
+  const banKey = `minigames_ban:${playerId}`;
+  const ban = await getVariable(gameServerId, moduleId, banKey);
+  if (ban !== null) {
+    if (ban.expiresAt && new Date(ban.expiresAt) < new Date()) {
+      // Expired ban — clean it up silently
+      await deleteVariable(gameServerId, moduleId, banKey);
+    } else {
+      const expMsg = ban.expiresAt
+        ? ` until ${new Date(ban.expiresAt).toUTCString()}`
+        : ' permanently';
+      throw new TakaroUserError(`You are banned from mini-games${expMsg}.`);
+    }
+  }
+
+  const cap = config.dailyPointsCapPerPlayer ?? 0;
+  if (cap === 0) return { remainingToday: Infinity };
+
+  const windowKey = `minigames_window:${playerId}:${todayUTC()}`;
+  const window = await getVariable(gameServerId, moduleId, windowKey);
+  const earned = window ? (window.earned ?? 0) : 0;
+  const remaining = cap - earned;
+  // Do NOT throw when cap is hit — return remainingToday: 0 so callers can still
+  // participate in live rounds (they just won't earn any points). Async puzzles
+  // can choose to inform the player using this value.
+  return { remainingToday: Math.max(remaining, 0) };
+}
+
+export async function recordPlay(gameServerId, moduleId, playerId, game) {
+  // Increment play count regardless of win/loss outcome.
+  const statsKey = `minigames_stats:${playerId}`;
+  const stats = await getVariable(gameServerId, moduleId, statsKey) ?? {
+    totalPoints: 0,
+    gamesPlayed: 0,
+    biggestScore: { points: 0, game: null, at: null },
+    perGame: {},
+    streaks: { wordle: { current: 0, best: 0, lastSolvedDate: null } },
+  };
+  stats.gamesPlayed = (stats.gamesPlayed ?? 0) + 1;
+  if (!stats.perGame[game]) stats.perGame[game] = { points: 0, plays: 0, wins: 0 };
+  stats.perGame[game].plays = (stats.perGame[game].plays ?? 0) + 1;
+  await setVariable(gameServerId, moduleId, statsKey, stats);
+}
+
+export async function awardPoints({ gameServerId, moduleId, pog, game, points, config, playerName }) {
+  const { remainingToday } = await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+
+  // Apply boost tier
+  const boostResult = checkPermission(pog, 'MINIGAMES_BOOST');
+  const tier = Math.min(boostResult ? (boostResult.count ?? 0) : 0, 4);
+  const multiplier = 1 + tier * 0.25;
+  const boostedPoints = Math.round(points * multiplier);
+
+  // Clip to daily cap (0 when cap is exhausted)
+  const actualPoints = remainingToday === Infinity ? boostedPoints : Math.min(boostedPoints, remainingToday);
+  // Full cap: player earned nothing because daily limit was already at 0
+  const cappedByDaily = actualPoints === 0 && boostedPoints > 0;
+  // Partial cap: player earned something but less than they would have without the cap
+  const clippedByDaily = !cappedByDaily && boostedPoints > actualPoints && remainingToday < boostedPoints;
+
+  // Update daily window only if points were earned
+  if (actualPoints > 0) {
+    const windowKey = `minigames_window:${pog.playerId}:${todayUTC()}`;
+    const window = await getVariable(gameServerId, moduleId, windowKey) ?? { earned: 0 };
+    window.earned = (window.earned ?? 0) + actualPoints;
+    await setVariable(gameServerId, moduleId, windowKey, window);
+  }
+
+  // Update lifetime stats — wins always increment regardless of cap; points only if earned
+  const statsKey = `minigames_stats:${pog.playerId}`;
+  const stats = await getVariable(gameServerId, moduleId, statsKey) ?? {
+    totalPoints: 0,
+    gamesPlayed: 0,
+    biggestScore: { points: 0, game: null, at: null },
+    perGame: {},
+    streaks: { wordle: { current: 0, best: 0, lastSolvedDate: null } },
+  };
+
+  stats.totalPoints = (stats.totalPoints ?? 0) + actualPoints;
+
+  if (!stats.perGame[game]) stats.perGame[game] = { points: 0, plays: 0, wins: 0 };
+  stats.perGame[game].points += actualPoints;
+  // wins always increments — a cap-exhausted win still counts as a win on leaderboards
+  stats.perGame[game].wins = (stats.perGame[game].wins ?? 0) + 1;
+
+  if (actualPoints > 0 && actualPoints > (stats.biggestScore?.points ?? 0)) {
+    stats.biggestScore = { points: actualPoints, game, at: new Date().toISOString() };
+  }
+
+  await setVariable(gameServerId, moduleId, statsKey, stats);
+
+  // Currency conversion — skip if no points earned
+  let currencyPaid = 0;
+  if (actualPoints > 0) {
+    const rate = config.pointsToCurrencyRate ?? 0;
+    if (rate > 0) {
+      currencyPaid = Math.round(actualPoints * rate);
+      if (currencyPaid > 0) {
+        await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, pog.playerId, {
+          currency: currencyPaid,
+        });
+      }
+    }
+  }
+
+  // Big score event — only fires when actual points were earned
+  if (actualPoints > 0) {
+    const threshold = config.bigScoreThreshold ?? 500;
+    if (actualPoints >= threshold) {
+      // Use provided playerName, or fall back to fetching from Takaro, or generic label
+      let displayName = playerName ?? pog.player?.name;
+      if (!displayName) {
+        try {
+          const playerRes = await takaro.player.playerControllerGetOne(pog.playerId);
+          displayName = playerRes.data.data.name;
+        } catch {
+          displayName = 'A player';
+        }
+      }
+      await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+        message: `🎉 BIG SCORE! ${displayName} just scored ${actualPoints} points in ${game}!`,
+        opts: {},
+      });
+    }
+  }
+
+  return { actualPoints, currencyPaid, newTotal: stats.totalPoints, boostedPoints, multiplier, cappedByDaily, clippedByDaily };
+}
+
+export async function updateWordleStreak(gameServerId, moduleId, playerId, solved) {
+  const statsKey = `minigames_stats:${playerId}`;
+  const stats = await getVariable(gameServerId, moduleId, statsKey) ?? {
+    totalPoints: 0, gamesPlayed: 0,
+    biggestScore: { points: 0, game: null, at: null },
+    perGame: {},
+    streaks: { wordle: { current: 0, best: 0, lastSolvedDate: null } },
+  };
+  if (!stats.streaks) stats.streaks = { wordle: { current: 0, best: 0, lastSolvedDate: null } };
+  if (!stats.streaks.wordle) stats.streaks.wordle = { current: 0, best: 0, lastSolvedDate: null };
+
+  const today = todayUTC();
+  const streak = stats.streaks.wordle;
+
+  if (solved) {
+    // Extend streak only if we haven't already solved today
+    if (streak.lastSolvedDate !== today) {
+      // Check if yesterday was the last solve (consecutive)
+      const yesterday = new Date();
+      yesterday.setUTCDate(yesterday.getUTCDate() - 1);
+      const yesterdayStr = yesterday.toISOString().slice(0, 10);
+      if (streak.lastSolvedDate === yesterdayStr || streak.lastSolvedDate === null) {
+        streak.current = (streak.current ?? 0) + 1;
+      } else {
+        streak.current = 1; // streak broken
+      }
+      streak.best = Math.max(streak.best ?? 0, streak.current);
+      streak.lastSolvedDate = today;
+    }
+  } else {
+    // Failed today's puzzle — streak resets only if we haven't solved it yet
+    if (streak.lastSolvedDate !== today) {
+      streak.current = 0;
+    }
+  }
+
+  await setVariable(gameServerId, moduleId, statsKey, stats);
+}
+
+// ─── Live round fire helpers ──────────────────────────────────────────────────
+
+export function fisherYatesShuffle(arr) {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+export async function getActiveRound(gameServerId, moduleId) {
+  return await getVariable(gameServerId, moduleId, 'minigames_active_round');
+}
+
+export async function setActiveRound(gameServerId, moduleId, round) {
+  await setVariable(gameServerId, moduleId, 'minigames_active_round', round);
+}
+
+export async function clearActiveRound(gameServerId, moduleId) {
+  await deleteVariable(gameServerId, moduleId, 'minigames_active_round');
+}
+
+// ─── Content bank lazy-create helpers ────────────────────────────────────────
+
+export async function getContentBank(gameServerId, moduleId, key, defaultShape) {
+  const existing = await getVariable(gameServerId, moduleId, key);
+  if (existing !== null) return existing;
+  // Lazy-create empty
+  await setVariable(gameServerId, moduleId, key, defaultShape);
+  return defaultShape;
+}
+
+// ─── Admin warning helper ─────────────────────────────────────────────────────
+
+export async function warnAdminEmptyBank(gameServerId, moduleId, missingKeys) {
+  if (missingKeys.length === 0) return;
+  const warnKey = 'minigames_admin_warned_empty_bank';
+  const today = todayUTC();
+  const warned = await getVariable(gameServerId, moduleId, warnKey) ?? { date: null, keys: [] };
+
+  const newKeys = missingKeys.filter(k => warned.date !== today || !warned.keys.includes(k));
+  if (newKeys.length === 0) return;
+
+  await setVariable(gameServerId, moduleId, warnKey, { date: today, keys: [...new Set([...warned.keys, ...newKeys])] });
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `⚠️ [miniGames] Admin notice: content bank(s) are empty — no puzzle for today. Missing variable keys: ${newKeys.join(', ')}. Paste word lists / questions via the Takaro UI Variables tab.`,
+    opts: {},
+  });
+}
+
+// ─── Normalise answer for comparison ──────────────────────────────────────────
+
+export function normaliseAnswer(s) {
+  if (s === null || s === undefined) return '';
+  return String(s).trim().toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// ─── Math race expression generator ──────────────────────────────────────────
+
+export function generateMathProblem() {
+  const ops = ['+', '-', '*', '/'];
+  for (let attempt = 0; attempt < 50; attempt++) {
+    const useThreeOperands = Math.random() < 0.5;
+    let expr, result;
+
+    if (!useThreeOperands) {
+      const a = rand(2, 30);
+      const b = rand(2, 30);
+      const op = ops[Math.floor(Math.random() * ops.length)];
+      if (op === '/') {
+        if (b === 0 || a % b !== 0) continue;
+        result = a / b;
+      } else if (op === '+') { result = a + b; }
+      else if (op === '-') { result = a - b; }
+      else { result = a * b; }
+      expr = `${a} ${opSymbol(op)} ${b}`;
+    } else {
+      const a = rand(2, 20);
+      const b = rand(2, 20);
+      const c = rand(2, 20);
+      const op1 = ops[Math.floor(Math.random() * ops.length)];
+      const op2 = ops[Math.floor(Math.random() * ops.length)];
+      // Compute left-to-right (simplified, no precedence ambiguity via display)
+      let left;
+      if (op1 === '/') { if (a % b !== 0) continue; left = a / b; }
+      else if (op1 === '+') { left = a + b; }
+      else if (op1 === '-') { left = a - b; }
+      else { left = a * b; }
+
+      if (op2 === '/') { if (left % c !== 0) continue; result = left / c; }
+      else if (op2 === '+') { result = left + c; }
+      else if (op2 === '-') { result = left - c; }
+      else { result = left * c; }
+      expr = `${a} ${opSymbol(op1)} ${b} ${opSymbol(op2)} ${c}`;
+    }
+
+    if (!Number.isInteger(result)) continue;
+    if (result < -500 || result > 10000) continue;
+    return { expr, result };
+  }
+  // Fallback: simple addition
+  const a = rand(10, 99);
+  const b = rand(10, 99);
+  return { expr: `${a} + ${b}`, result: a + b };
+}
+
+function rand(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function opSymbol(op) {
+  return op === '*' ? '×' : op === '/' ? '÷' : op;
+}
+
+// ─── Shared live-round fire logic ─────────────────────────────────────────────
+// Called by both fireLiveRound cronjob and minigamesfirenow command.
+// forcedGame: optional string to force a specific game; if omitted, picks randomly.
+// onNoGames: callback(reason) when no game can be started (cronjob logs; command throws).
+// Returns the round object that was written, or null if skipped.
+
+const REACTION_TOKENS_LIST = ['!first', '!go', '!grab', '!now', '!claim'];
+
+export async function buildAndFireLiveRound(gameServerId, moduleId, config, forcedGame) {
+  const games = config.games ?? {};
+  const liveGames = ['trivia', 'scramble', 'mathrace', 'reactionrace'].filter(g => games[g] !== false);
+
+  let game;
+  if (forcedGame) {
+    if (!['trivia', 'scramble', 'mathrace', 'reactionrace'].includes(forcedGame)) {
+      throw new TakaroUserError(`Unknown live game: "${forcedGame}". Valid: trivia, scramble, mathrace, reactionrace`);
+    }
+    if (games[forcedGame] === false) {
+      throw new TakaroUserError(`Game "${forcedGame}" is disabled in config.`);
+    }
+    game = forcedGame;
+  } else {
+    if (liveGames.length === 0) return null;
+    game = liveGames[Math.floor(Math.random() * liveGames.length)];
+  }
+
+  const answerWindowSec = config.liveRoundAnswerWindowSec ?? 60;
+  const expiresAt = new Date(Date.now() + answerWindowSec * 1000).toISOString();
+  let round;
+
+  if (game === 'mathrace') {
+    const { expr, result } = generateMathProblem();
+    round = { game, prompt: expr, answer: result, answerType: 'number', startedAt: new Date().toISOString(), expiresAt };
+    await setActiveRound(gameServerId, moduleId, round);
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `➗ MATH: ${expr} = ? — /answer <number> (${answerWindowSec}s)`,
+      opts: {},
+    });
+
+  } else if (game === 'scramble') {
+    const bank = await getContentBank(gameServerId, moduleId, 'minigames_content_wordlist', { words: [] });
+    const words = (bank.words ?? []).filter(w => /^[a-z]+$/.test(w) && w.length >= 4);
+    if (words.length === 0) {
+      await warnAdminEmptyBank(gameServerId, moduleId, ['minigames_content_wordlist']);
+      return null;
+    }
+    const word = words[Math.floor(Math.random() * words.length)].toLowerCase();
+    let scrambled = word;
+    for (let i = 0; i < 5 && scrambled === word; i++) {
+      scrambled = fisherYatesShuffle(word.split('')).join('');
+    }
+    round = { game, prompt: scrambled.toUpperCase(), answer: word, answerType: 'text', startedAt: new Date().toISOString(), expiresAt };
+    await setActiveRound(gameServerId, moduleId, round);
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `🔤 SCRAMBLE: ${scrambled.toUpperCase()} — /answer <word> (${answerWindowSec}s)`,
+      opts: {},
+    });
+
+  } else if (game === 'reactionrace') {
+    const token = REACTION_TOKENS_LIST[Math.floor(Math.random() * REACTION_TOKENS_LIST.length)];
+    round = { game, prompt: token, answer: token, answerType: 'rawchat', startedAt: new Date().toISOString(), expiresAt };
+    await setActiveRound(gameServerId, moduleId, round);
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `⚡ REACTION: first to type ${token} in chat wins! (${answerWindowSec}s)`,
+      opts: {},
+    });
+
+  } else if (game === 'trivia') {
+    let questionData = null;
+
+    if (config.triviaQuestionSource !== 'custom') {
+      try {
+        let url = 'https://opentdb.com/api.php?amount=1';
+        const categories = config.triviaApiCategory ?? ['any'];
+        const nonAnyCategories = categories.filter(c => c !== 'any');
+        if (nonAnyCategories.length > 0) {
+          const catKey = nonAnyCategories[Math.floor(Math.random() * nonAnyCategories.length)];
+          const catId = OPENTDB_CATEGORIES[catKey];
+          if (catId) url += `&category=${catId}`;
+        }
+        if (config.triviaApiDifficulty && config.triviaApiDifficulty !== 'any') url += `&difficulty=${config.triviaApiDifficulty}`;
+        if (config.triviaApiType && config.triviaApiType !== 'any') url += `&type=${config.triviaApiType}`;
+
+        const response = await takaro.axios.get(url);
+        if (response.data?.response_code === 0 && response.data?.results?.length > 0) {
+          const q = response.data.results[0];
+          questionData = {
+            question: decodeHtmlEntities(q.question),
+            answer: decodeHtmlEntities(q.correct_answer),
+            incorrectAnswers: (q.incorrect_answers ?? []).map(decodeHtmlEntities),
+            type: q.type === 'boolean' ? 'boolean' : 'multiple',
+          };
+        }
+      } catch (apiErr) {
+        console.error(`miniGames: OpenTDB fetch failed, falling back to custom bank. Error: ${apiErr}`);
+      }
+    }
+
+    if (!questionData) {
+      const bank = await getContentBank(gameServerId, moduleId, 'minigames_content_trivia', { questions: [] });
+      const questions = bank.questions ?? [];
+      if (questions.length === 0) {
+        await warnAdminEmptyBank(gameServerId, moduleId, ['minigames_content_trivia']);
+        return null;
+      }
+      const q = questions[Math.floor(Math.random() * questions.length)];
+      if (q.options && typeof q.answerIndex === 'number') {
+        questionData = {
+          question: q.question,
+          answer: q.options[q.answerIndex],
+          incorrectAnswers: q.options.filter((_, i) => i !== q.answerIndex),
+          type: 'multiple',
+        };
+      } else {
+        questionData = {
+          question: q.question,
+          answer: q.answer,
+          incorrectAnswers: q.incorrectAnswers ?? [],
+          type: q.incorrectAnswers?.length > 0 ? 'multiple' : 'text',
+        };
+      }
+    }
+
+    let displayedOptions = null;
+    let announcement;
+    if (questionData.type === 'boolean') {
+      displayedOptions = ['True', 'False'];
+      announcement = `❓ TRIVIA: ${questionData.question}\n/answer true or /answer false (${answerWindowSec}s)`;
+    } else if (questionData.type === 'multiple' && questionData.incorrectAnswers?.length > 0) {
+      const allOptions = fisherYatesShuffle([questionData.answer, ...questionData.incorrectAnswers]);
+      displayedOptions = allOptions;
+      announcement = `❓ TRIVIA: ${questionData.question}\nOptions: ${allOptions.join(', ')} — /answer <choice> (${answerWindowSec}s)`;
+    } else {
+      announcement = `❓ TRIVIA: ${questionData.question} — /answer <your guess> (${answerWindowSec}s)`;
+    }
+
+    round = {
+      game,
+      prompt: questionData.question,
+      answer: questionData.answer,
+      answerType: 'text',
+      displayedOptions,
+      startedAt: new Date().toISOString(),
+      expiresAt,
+    };
+    await setActiveRound(gameServerId, moduleId, round);
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: announcement,
+      opts: {},
+    });
+  }
+
+  return round ?? null;
+}

--- a/modules/mini-games/src/hooks/on-chat-message/index.js
+++ b/modules/mini-games/src/hooks/on-chat-message/index.js
@@ -1,0 +1,84 @@
+import { data, takaro, checkPermission } from '@takaro/helpers';
+import { getActiveRound, clearActiveRound, awardPoints, recordPlay, findPogByPlayerId, checkBanAndCap } from './mini-games-helpers.js';
+
+async function main() {
+  const { gameServerId, eventData, player, module: mod } = data;
+
+  if (!player || !player.id) {
+    console.log('miniGames onChatMessage: no player in event, ignoring');
+    return;
+  }
+
+  const moduleId = mod.moduleId;
+  const config = mod.userConfig;
+
+  const round = await getActiveRound(gameServerId, moduleId);
+  if (!round || round.game !== 'reactionrace') return;
+
+  // Check if expired
+  if (round.expiresAt && new Date(round.expiresAt) < new Date()) return;
+
+  const msg = (eventData?.msg ?? '').trim().toLowerCase();
+  const token = round.answer.toLowerCase();
+
+  if (msg !== token) return;
+
+  // Potential winner — validate eligibility BEFORE clearing so a banned player
+  // cannot grief the round (it stays active for someone else to win).
+  const pog = await findPogByPlayerId(gameServerId, player.id);
+  if (!pog) {
+    console.error(`miniGames onChatMessage: could not find pog for player ${player.id}`);
+    return;
+  }
+
+  // Check MINIGAMES_PLAY permission
+  if (!checkPermission(pog, 'MINIGAMES_PLAY')) {
+    console.log(`miniGames onChatMessage: player ${player.id} lacks MINIGAMES_PLAY, ignoring`);
+    return;
+  }
+
+  // Check ban — if banned, silently ignore so the round stays active for others
+  try {
+    await checkBanAndCap(gameServerId, moduleId, pog.playerId, config);
+  } catch {
+    // Banned player; silently drop — round remains active for others
+    console.log(`miniGames onChatMessage: player ${player.id} is banned, ignoring`);
+    return;
+  }
+
+  // Re-read the round immediately before clearing to narrow the concurrent-winner race.
+  // The first eligible writer to find the round still active and delete it wins.
+  // A concurrent winner will also attempt clearActiveRound (a no-op delete) then call
+  // awardPoints — the plan acknowledges this as an acceptable known limitation.
+  const roundStillActive = await getActiveRound(gameServerId, moduleId);
+  // Compare startedAt (unique timestamp) rather than answer (only 5 tokens, 20% reuse chance).
+  // If the token happens to match a brand-new round, we don't want to credit this stale handler.
+  if (!roundStillActive || roundStillActive.game !== 'reactionrace' || roundStillActive.startedAt !== round.startedAt) {
+    // Another player already claimed this round, or a new round started
+    return;
+  }
+
+  // Clear the round — first writer wins the race
+  await clearActiveRound(gameServerId, moduleId);
+
+  await recordPlay(gameServerId, moduleId, pog.playerId, 'reactionrace');
+  const { actualPoints, multiplier, currencyPaid, cappedByDaily, clippedByDaily } = await awardPoints({
+    gameServerId, moduleId, pog, game: 'reactionrace', points: config.pointsReactionRaceWin ?? 20, config,
+    playerName: player.name,
+  });
+
+  const boostNote = multiplier > 1 ? ` (boost ×${multiplier.toFixed(2)})` : '';
+  const currencyNote = currencyPaid > 0 ? ` +${currencyPaid} currency` : '';
+  const capNote = cappedByDaily
+    ? ' Daily point cap reached — no points awarded.'
+    : clippedByDaily
+      ? ` Daily cap clipped reward to ${actualPoints} points.`
+      : '';
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `⚡ FIRST! @${player.name} snapped ${round.prompt}. +${actualPoints} points${boostNote}${currencyNote}.${capNote}`,
+    opts: {},
+  });
+}
+
+await main();

--- a/modules/mini-games/src/hooks/on-player-disconnect/index.js
+++ b/modules/mini-games/src/hooks/on-player-disconnect/index.js
@@ -1,0 +1,12 @@
+import { data } from '@takaro/helpers';
+
+async function main() {
+  const { player, gameServerId } = data;
+
+  // Sessions persist across disconnect — async puzzles can be resumed on reconnect.
+  // Live rounds continue unless the player was the only one online (not tracked here).
+  // No state change needed in v1. Log for observability.
+  console.log(`miniGames onPlayerDisconnect: player=${player?.name ?? 'unknown'} disconnected from server=${gameServerId}. Async puzzle sessions persist.`);
+}
+
+await main();

--- a/modules/mini-games/test/mini-games.test.ts
+++ b/modules/mini-games/test/mini-games.test.ts
@@ -1,0 +1,680 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// ─── Variable helpers ─────────────────────────────────────────────────────────
+
+async function setVar(client: Client, gameServerId: string, moduleId: string, key: string, value: unknown) {
+  const serialized = typeof value === 'string' ? value : JSON.stringify(value);
+  const existing = await client.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  if (existing.data.data.length > 0) {
+    await client.variable.variableControllerUpdate(existing.data.data[0].id, { value: serialized });
+  } else {
+    await client.variable.variableControllerCreate({ key, value: serialized, gameServerId, moduleId });
+  }
+}
+
+async function getVar(client: Client, gameServerId: string, moduleId: string, key: string): Promise<unknown> {
+  const res = await client.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  if (res.data.data.length === 0) return null;
+  try { return JSON.parse(res.data.data[0].value); } catch { return res.data.data[0].value; }
+}
+
+async function delVar(client: Client, gameServerId: string, moduleId: string, key: string) {
+  const res = await client.variable.variableControllerSearch({
+    filters: { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] },
+  });
+  for (const v of res.data.data) {
+    await client.variable.variableControllerDelete(v.id);
+  }
+}
+
+function todayUTC(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// ─── Command trigger helper ────────────────────────────────────────────────────
+
+async function runCommand(
+  client: Client,
+  ctx: MockServerContext,
+  prefix: string,
+  playerId: string,
+  commandLine: string,
+): Promise<{ success: boolean; logs: string[] }> {
+  const startTime = new Date();
+
+  await client.command.commandControllerTrigger(ctx.gameServer.id, {
+    msg: `${prefix}${commandLine}`,
+    playerId,
+  });
+
+  const event = await waitForEvent(client, {
+    eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+    gameserverId: ctx.gameServer.id,
+    after: startTime,
+    timeout: 30000,
+  });
+
+  const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+  const success = meta?.result?.success ?? false;
+  const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+  return { success, logs };
+}
+
+// ─── Cronjob trigger helper ────────────────────────────────────────────────────
+
+async function runCronjob(
+  client: Client,
+  ctx: MockServerContext,
+  moduleId: string,
+  cronjobId: string,
+): Promise<{ success: boolean; logs: string[] }> {
+  const startTime = new Date();
+
+  await client.cronjob.cronJobControllerTrigger({
+    gameServerId: ctx.gameServer.id,
+    cronjobId,
+    moduleId,
+  });
+
+  const event = await waitForEvent(client, {
+    eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+    gameserverId: ctx.gameServer.id,
+    after: startTime,
+    timeout: 30000,
+  });
+
+  const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+  const success = meta?.result?.success ?? false;
+  const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  return { success, logs };
+}
+
+function getCronjobId(mod: Awaited<ReturnType<typeof pushModule>>, name: string): string {
+  const cj = mod.latestVersion.cronJobs.find((c) => c.name === name);
+  if (!cj) throw new Error(`Cronjob '${name}' not found in module`);
+  return cj.id;
+}
+
+// ─── Test suite ──────────────────────────────────────────────────────────────
+
+describe('mini-games module', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let mod: Awaited<ReturnType<typeof pushModule>>;
+  let prefix: string;
+  let manageRoleId: string | undefined;
+  let playRoleId: string | undefined;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        liveRoundIntervalMinutes: 5,
+        minPlayersForLiveRound: 1,
+        liveRoundAnswerWindowSec: 15,
+        pointsWordleBase: 100,
+        pointsHangmanBase: 80,
+        pointsHotColdBase: 60,
+        pointsTriviaWin: 40,
+        pointsScrambleWin: 40,
+        pointsMathRaceWin: 40,
+        pointsReactionRaceWin: 20,
+        pointsToCurrencyRate: 0,
+        dailyPointsCapPerPlayer: 0,
+        bigScoreThreshold: 9999,
+        triviaQuestionSource: 'custom',
+      },
+    });
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Grant MINIGAMES_PLAY and MINIGAMES_MANAGE to player[0]
+    assert.ok(ctx.players[0], 'Need at least 1 player');
+    playRoleId = await assignPermissions(client, ctx.players[0].playerId, ctx.gameServer.id, ['MINIGAMES_PLAY']);
+    manageRoleId = await assignPermissions(client, ctx.players[0].playerId, ctx.gameServer.id, ['MINIGAMES_MANAGE']);
+
+    // Allow the module and permissions to fully propagate before running commands
+    await new Promise((r) => setTimeout(r, 2000));
+  });
+
+  after(async () => {
+    await cleanupRole(client, playRoleId);
+    await cleanupRole(client, manageRoleId);
+    try { await uninstallModule(client, moduleId, ctx.gameServer.id); } catch {}
+    try { await deleteModule(client, moduleId); } catch {}
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  const player0 = () => ctx.players[0]!;
+
+  // ─── Help command ────────────────────────────────────────────────────────────
+
+  describe('minigames help command', () => {
+    it('/minigames shows help overview', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigames');
+      assert.equal(success, true);
+    });
+
+    it('/minigames wordle shows per-game help', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigames wordle');
+      assert.equal(success, true);
+    });
+  });
+
+  // ─── Rollover cronjob ────────────────────────────────────────────────────────
+
+  describe('rolloverDailyPuzzles cronjob', () => {
+    it('warns admin when content banks are empty and succeeds', async () => {
+      // Delete any existing content banks so they are empty
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_content_wordle');
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_content_wordlist');
+
+      const cronjobId = getCronjobId(mod, 'rolloverDailyPuzzles');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `Cronjob failed. Logs: ${JSON.stringify(logs)}`);
+    });
+
+    it('sets minigames_puzzle_today when banks are seeded', async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_content_wordle', {
+        words: ['crane', 'slate', 'tiger', 'brave', 'storm'],
+      });
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_content_wordlist', {
+        words: ['takaro', 'gaming', 'server', 'player', 'module'],
+      });
+
+      const cronjobId = getCronjobId(mod, 'rolloverDailyPuzzles');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `Cronjob failed. Logs: ${JSON.stringify(logs)}`);
+
+      const puzzle = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_puzzle_today')) as any;
+      assert.ok(puzzle, 'Expected minigames_puzzle_today to be set');
+      assert.equal(puzzle.date, todayUTC(), 'Puzzle date should be today');
+      assert.ok(puzzle.wordle, 'Expected wordle word to be set');
+      assert.ok(puzzle.hangman, 'Expected hangman word to be set');
+      assert.ok(puzzle.hotcold !== undefined && puzzle.hotcold !== null, 'Expected hotcold secret to be set');
+      assert.ok(/^[a-z]{5}$/.test(puzzle.wordle), `Wordle word '${puzzle.wordle}' must be 5 lowercase letters`);
+    });
+  });
+
+  // ─── Wordle ─────────────────────────────────────────────────────────────────
+
+  describe('wordle command', () => {
+    before(async () => {
+      // Set a known puzzle
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_puzzle_today', {
+        date: todayUTC(),
+        wordle: 'crane',
+        hangman: 'takaro',
+        hotcold: 500,
+      });
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_content_wordle', {
+        words: ['crane', 'slate', 'tiger', 'brave', 'storm'],
+      });
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:wordle`);
+    });
+
+    it('shows status with no guesses', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle');
+      assert.equal(success, true);
+    });
+
+    it('rejects guess that is not 5 letters (handled as user error)', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle abc');
+      assert.equal(success, false, 'TakaroUserError should yield success=false');
+    });
+
+    it('rejects word not in bank', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle zzzzz');
+      assert.equal(success, false, 'TakaroUserError should yield success=false');
+    });
+
+    it('accepts a valid guess from the bank', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle slate');
+      assert.equal(success, true);
+    });
+
+    it('solves wordle with correct word and awards points', async () => {
+      // Clear session to start fresh
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:wordle`);
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle crane');
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const stats = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`)) as any;
+      assert.ok(stats, 'Stats should be set after winning');
+      assert.ok((stats.totalPoints ?? 0) > 0, 'Total points should be positive');
+      assert.ok((stats.perGame?.wordle?.wins ?? 0) >= 1, 'Wordle wins should be at least 1');
+    });
+  });
+
+  // ─── Hangman ─────────────────────────────────────────────────────────────────
+
+  describe('hangman command', () => {
+    before(async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:hangman`);
+    });
+
+    it('shows status with no session', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hangman');
+      assert.equal(success, true);
+    });
+
+    it('accepts a letter guess', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hangman t');
+      assert.equal(success, true);
+    });
+
+    it('solves hangman with full word', async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:hangman`);
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hangman takaro');
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const stats = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`)) as any;
+      assert.ok((stats?.perGame?.hangman?.wins ?? 0) >= 1, 'Hangman wins should be at least 1');
+    });
+  });
+
+  // ─── Hot/Cold ─────────────────────────────────────────────────────────────────
+
+  describe('hotcold command', () => {
+    before(async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_puzzle_today', {
+        date: todayUTC(),
+        wordle: 'crane',
+        hangman: 'takaro',
+        hotcold: 42,
+      });
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:hotcold`);
+    });
+
+    it('shows status with no guesses', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hotcold');
+      assert.equal(success, true);
+    });
+
+    it('rejects out-of-range guess', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hotcold 1001');
+      assert.equal(success, false, 'TakaroUserError should yield success=false');
+    });
+
+    it('accepts a valid guess', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hotcold 500');
+      assert.equal(success, true);
+    });
+
+    it('solves with exact guess', async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:hotcold`);
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'hotcold 42');
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const stats = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`)) as any;
+      assert.ok((stats?.perGame?.hotcold?.wins ?? 0) >= 1, 'Hot/Cold wins should be at least 1');
+    });
+  });
+
+  // ─── Math race live round ─────────────────────────────────────────────────────
+
+  describe('math race live round', () => {
+    before(async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+    });
+
+    it('fires math race via admin command', async () => {
+      const { success, logs } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamesfirenow mathrace');
+      assert.equal(success, true, `minigamesfirenow failed. Logs: ${JSON.stringify(logs)}`);
+
+      await new Promise((r) => setTimeout(r, 1000));
+      const round = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round')) as any;
+      assert.ok(round, 'Expected active round after fire');
+      assert.equal(round.game, 'mathrace');
+      assert.ok(round.answer !== undefined, 'Round should have an answer');
+    });
+
+    it('correct /answer wins the round and awards points', async () => {
+      const round = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round')) as any;
+      assert.ok(round, 'Need an active round for this test');
+
+      const statsBefore = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`)) as any;
+      const ptsBefore = statsBefore?.totalPoints ?? 0;
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, `answer ${round.answer}`);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 1000));
+
+      const roundAfter = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(roundAfter, null, 'Active round should be cleared after correct answer');
+
+      const statsAfter = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`)) as any;
+      assert.ok((statsAfter?.totalPoints ?? 0) > ptsBefore, 'Points should increase after winning math race');
+    });
+  });
+
+  // ─── Scramble live round ──────────────────────────────────────────────────────
+
+  describe('scramble live round', () => {
+    before(async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+    });
+
+    it('fires scramble and correct answer wins', async () => {
+      const { success: fireSuccess } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamesfirenow scramble');
+      assert.equal(fireSuccess, true);
+      await new Promise((r) => setTimeout(r, 1000));
+
+      const round = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round')) as any;
+      assert.ok(round, 'Expected active scramble round');
+      assert.equal(round.game, 'scramble');
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, `answer ${round.answer}`);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const roundAfter = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(roundAfter, null, 'Round should be cleared after win');
+    });
+  });
+
+  // ─── Trivia (custom bank) ──────────────────────────────────────────────────────
+
+  describe('trivia live round (custom bank)', () => {
+    before(async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_content_trivia', {
+        questions: [
+          { question: 'What is 2 plus 2?', answer: 'four', incorrectAnswers: ['three', 'five', 'six'] },
+        ],
+      });
+    });
+
+    it('fires trivia and correct answer wins', async () => {
+      const { success: fireSuccess } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamesfirenow trivia');
+      assert.equal(fireSuccess, true);
+      await new Promise((r) => setTimeout(r, 1000));
+
+      const round = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round')) as any;
+      assert.ok(round, 'Expected active trivia round');
+      assert.equal(round.game, 'trivia');
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, `answer ${round.answer}`);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const roundAfter = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(roundAfter, null, 'Round should be cleared after win');
+    });
+  });
+
+  // ─── closeLiveRound cronjob ────────────────────────────────────────────────────
+
+  describe('closeLiveRound cronjob', () => {
+    it('closes an expired round', async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round', {
+        game: 'mathrace',
+        prompt: '1 + 1',
+        answer: 2,
+        answerType: 'number',
+        startedAt: new Date(Date.now() - 120000).toISOString(),
+        expiresAt: new Date(Date.now() - 60000).toISOString(),
+      });
+
+      const cronjobId = getCronjobId(mod, 'closeLiveRound');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `closeLiveRound failed. Logs: ${JSON.stringify(logs)}`);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const roundAfter = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(roundAfter, null, 'Expired round should be cleared');
+    });
+  });
+
+  // ─── fireLiveRound cronjob ────────────────────────────────────────────────────
+
+  describe('fireLiveRound cronjob', () => {
+    before(async () => {
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_last_round_firedAt');
+    });
+
+    it('fires a round when interval elapsed and players online', async () => {
+      const cronjobId = getCronjobId(mod, 'fireLiveRound');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `fireLiveRound failed. Logs: ${JSON.stringify(logs)}`);
+
+      await new Promise((r) => setTimeout(r, 1000));
+      const round = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.ok(round, 'Expected live round to be created');
+      await delVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+    });
+
+    it('skips when interval has not elapsed', async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_last_round_firedAt', new Date().toISOString());
+
+      const cronjobId = getCronjobId(mod, 'fireLiveRound');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `fireLiveRound failed. Logs: ${JSON.stringify(logs)}`);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const round = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(round, null, 'Should not fire when interval has not elapsed');
+    });
+  });
+
+  // ─── refreshLeaderboards cronjob ──────────────────────────────────────────────
+
+  describe('refreshLeaderboards cronjob', () => {
+    it('generates the leaderboard cache', async () => {
+      const cronjobId = getCronjobId(mod, 'refreshLeaderboards');
+      const { success, logs } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true, `refreshLeaderboards failed. Logs: ${JSON.stringify(logs)}`);
+
+      const cache = (await getVar(client, ctx.gameServer.id, moduleId, 'minigames_leaderboard_cache')) as any;
+      assert.ok(cache, 'Leaderboard cache should be set');
+      assert.ok(Array.isArray(cache.topPoints), 'topPoints should be an array');
+      assert.ok(cache.refreshedAt, 'refreshedAt should be set');
+    });
+  });
+
+  // ─── Daily point cap ──────────────────────────────────────────────────────────
+
+  describe('daily point cap', () => {
+    it('clips points to the daily cap', async () => {
+      // Reinstall with tight cap
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+      await installModule(client, versionId, ctx.gameServer.id, {
+        userConfig: {
+          dailyPointsCapPerPlayer: 30,
+          pointsWordleBase: 100,
+          triviaQuestionSource: 'custom',
+          liveRoundIntervalMinutes: 5,
+          minPlayersForLiveRound: 1,
+          liveRoundAnswerWindowSec: 15,
+        },
+      });
+
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_window:${player0().playerId}:${todayUTC()}`);
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_puzzle_today', {
+        date: todayUTC(),
+        wordle: 'brave',
+        hangman: 'server',
+        hotcold: 888,
+      });
+      await delVar(client, ctx.gameServer.id, moduleId, `minigames_session:${player0().playerId}:wordle`);
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'wordle brave');
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const window = (await getVar(client, ctx.gameServer.id, moduleId, `minigames_window:${player0().playerId}:${todayUTC()}`)) as any;
+      assert.ok(window, 'Daily window should be set');
+      assert.ok((window.earned ?? 0) <= 30, `Earned ${window.earned} should be <= cap of 30`);
+
+      // Restore config
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+      await installModule(client, versionId, ctx.gameServer.id, {
+        userConfig: {
+          triviaQuestionSource: 'custom',
+          liveRoundIntervalMinutes: 5,
+          minPlayersForLiveRound: 1,
+          liveRoundAnswerWindowSec: 15,
+          bigScoreThreshold: 9999,
+        },
+      });
+    });
+  });
+
+  // ─── Ban / unban ──────────────────────────────────────────────────────────────
+
+  describe('ban and unban admin commands', () => {
+    it('ban sets the ban variable', async () => {
+      const victim = ctx.players[1] ?? ctx.players[0];
+      await runCommand(client, ctx, prefix, player0().playerId, `minigamesban ${victim.gameId}`);
+      await new Promise((r) => setTimeout(r, 500));
+
+      const ban = await getVar(client, ctx.gameServer.id, moduleId, `minigames_ban:${victim.playerId}`);
+      assert.ok(ban !== null, 'Ban variable should be set');
+
+      // Unban
+      await runCommand(client, ctx, prefix, player0().playerId, `minigamesunban ${victim.gameId}`);
+      await new Promise((r) => setTimeout(r, 500));
+
+      const banAfter = await getVar(client, ctx.gameServer.id, moduleId, `minigames_ban:${victim.playerId}`);
+      assert.equal(banAfter, null, 'Ban should be removed after unban');
+    });
+  });
+
+  // ─── expireBans cronjob ────────────────────────────────────────────────────────
+
+  describe('expireBans cronjob', () => {
+    it('removes expired ban variables', async () => {
+      const pid = player0().playerId;
+      await setVar(client, ctx.gameServer.id, moduleId, `minigames_ban:${pid}`, {
+        expiresAt: new Date(Date.now() - 5000).toISOString(),
+      });
+
+      const cronjobId = getCronjobId(mod, 'expireBans');
+      const { success } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const banAfter = await getVar(client, ctx.gameServer.id, moduleId, `minigames_ban:${pid}`);
+      assert.equal(banAfter, null, 'Expired ban should be removed');
+    });
+  });
+
+  // ─── expireWindows cronjob ────────────────────────────────────────────────────
+
+  describe('expireWindows cronjob', () => {
+    it('removes old window variables', async () => {
+      const pid = player0().playerId;
+      await setVar(client, ctx.gameServer.id, moduleId, `minigames_window:${pid}:2000-01-01`, { earned: 100 });
+
+      const cronjobId = getCronjobId(mod, 'expireWindows');
+      const { success } = await runCronjob(client, ctx, moduleId, cronjobId);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const windowAfter = await getVar(client, ctx.gameServer.id, moduleId, `minigames_window:${pid}:2000-01-01`);
+      assert.equal(windowAfter, null, 'Old window variable should be deleted');
+    });
+  });
+
+  // ─── Stats and leaderboard commands ──────────────────────────────────────────
+
+  describe('stats and leaderboard commands', () => {
+    it('/minigamestats returns stats', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamestats');
+      assert.equal(success, true);
+    });
+
+    it('/minigamestop points returns leaderboard', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamestop points');
+      assert.equal(success, true);
+    });
+
+    it('/puzzle shows daily puzzle status', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'puzzle');
+      assert.equal(success, true);
+    });
+  });
+
+  // ─── Admin commands ────────────────────────────────────────────────────────────
+
+  describe('admin commands', () => {
+    it('/minigamesskiproundnow cancels active round', async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round', {
+        game: 'mathrace',
+        prompt: '2 + 2',
+        answer: 4,
+        answerType: 'number',
+        startedAt: new Date().toISOString(),
+        expiresAt: new Date(Date.now() + 60000).toISOString(),
+      });
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamesskiproundnow');
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const round = await getVar(client, ctx.gameServer.id, moduleId, 'minigames_active_round');
+      assert.equal(round, null, 'Active round should be cleared');
+    });
+
+    it('/minigamesresetstats deletes stats', async () => {
+      await setVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`, { totalPoints: 9999 });
+
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, `minigamesresetstats ${player0().gameId}`);
+      assert.equal(success, true);
+
+      await new Promise((r) => setTimeout(r, 500));
+      const stats = await getVar(client, ctx.gameServer.id, moduleId, `minigames_stats:${player0().playerId}`);
+      assert.equal(stats, null, 'Stats should be deleted after reset');
+    });
+
+    it('/minigamesreport completes successfully', async () => {
+      const { success } = await runCommand(client, ctx, prefix, player0().playerId, 'minigamesreport');
+      assert.equal(success, true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `mini-games` Takaro module that bundles seven skill-based mini-games under one roof: three async daily puzzles (Wordle, Hangman, Hot/Cold) and four live chat rounds (Trivia, Scramble, Math race, Reaction race). Everything routes through a shared scorer that awards points, optionally converts points to currency, enforces daily point caps at UTC rollover, applies a count-based boost-tier permission (1–4 → +25%/tier, capped at 2.0×), and emits big-score events for `chatBridge` Discord relay.

Before this PR, admins had to install individual modules (`Hangman`, `7dtd_triviaTime`) that couldn't share stats, leaderboards, or boost tiers. This module replaces that fragmentation with one install, one config, and cross-game shared infrastructure.

## Architecture

```
                ┌──────────────────────┐
                │  module.json         │  (config schema, permissions,
                │                      │   command/hook/cronjob registry)
                └──────────┬───────────┘
                           │
                ┌──────────▼────────────────────────────────┐
                │  src/functions/mini-games-helpers.js      │
                │  (scorer prelude — THE architectural      │
                │   keystone; every component imports it)   │
                │                                           │
                │  • checkBanAndCap                         │
                │  • recordPlay                             │
                │  • awardPoints (returns cappedByDaily /   │
                │    clippedByDaily flags)                  │
                │  • buildAndFireLiveRound                  │
                │  • findPogByPlayerId / findPlayerByName / │
                │    findPlayerByGameId                     │
                │  • updateWordleStreak                     │
                │  • OPENTDB_CATEGORIES, decodeHtmlEntities │
                └──────────┬────────────────────────────────┘
                           │ imported by every file below
        ┌──────────────────┼──────────────────────────┐
        ▼                  ▼                          ▼
   ┌─────────┐        ┌──────────┐           ┌───────────────┐
   │commands │        │ cronjobs │           │ hooks         │
   │ (14)    │        │ (6)      │           │ (2)           │
   │         │        │          │           │               │
   │wordle   │        │rollover  │           │onChatMessage  │
   │hangman  │        │DailyPuz  │           │(reaction race │
   │hotcold  │        │fireLive  │           │ winner catch) │
   │answer   │        │ Round    │           │               │
   │puzzle   │        │closeLive │           │onPlayer       │
   │minigames│        │ Round    │           │ Disconnect    │
   │stats,top│        │refreshLB │           │               │
   │ban/unban│        │expire    │           │               │
   │firenow… │        │ Windows  │           │               │
   │         │        │expireBans│           │               │
   └─────────┘        └──────────┘           └───────────────┘

          Takaro Variables (scoped by moduleId + gameServerId)
  ┌─────────────────────────────────────────────────────────────┐
  │ minigames_content_wordle / wordlist / trivia (admin-seeded) │
  │ minigames_puzzle_today (daily)                              │
  │ minigames_session:{pid}:{game} (per-player puzzle state)    │
  │ minigames_active_round (live round)                         │
  │ minigames_stats:{pid} (lifetime stats)                      │
  │ minigames_window:{pid}:{YYYY-MM-DD} (daily cap state)       │
  │ minigames_leaderboard_cache (every 5 min)                   │
  │ minigames_ban:{pid} (presence = banned)                     │
  └─────────────────────────────────────────────────────────────┘
```

Patterns borrowed from `casino` (ledger-as-prelude → scorer-as-prelude), `lottery` (cronjob-driven rounds), `dailyRewards` (per-player window variables with UTC rollover), and `7dtd_triviaTime` (OpenTDB integration with HTML entity decoding + custom-bank fallback).

## What Changed

- **Module skeleton (`module.json`)** — declares config schema (behavioural knobs only, no content), systemConfigSchema, uiSchema, 4 permissions (`MINIGAMES_PLAY`, `MINIGAMES_BOOST` count-based, `MINIGAMES_MANAGE`), and registers all 14 commands / 2 hooks / 6 cronjobs / 1 function.
- **Shared scorer (`functions/mini-games-helpers.js`)** — the architectural keystone. Every game imports scorer helpers, per-game variable helpers, OpenTDB map, and the `buildAndFireLiveRound` dispatcher. ~470 lines.
- **Async daily puzzles** — `wordle`, `hangman`, `hotcold` commands. Per-player session state, streak tracking (Wordle only, per plan), `recordPlay` at every session completion regardless of outcome.
- **Live chat rounds** — shared `fireLiveRound` cronjob fires a random enabled game every `liveRoundIntervalMinutes` when `currentPlayerCount >= minPlayersForLiveRound`. `closeLiveRound` cronjob announces timeout if nobody answers. Universal `/answer` command dispatches based on the active round's game. Reaction race uses a `chat-message` hook (not `/answer`) so raw chat typing is the answer.
- **Admin tooling** — 6 admin commands gated on `MINIGAMES_MANAGE`: ban/unban (temporary via `minigames_ban:{pid}` variable, swept by `expireBans` cronjob), resetstats, skiproundnow, firenow (force a live round), report (lifetime stats PM).
- **Leaderboards** — `refreshLeaderboards` cronjob scans `minigames_stats:*`, batch-resolves player names via chunked `playerControllerSearch` (chunks of 100 with `Promise.allSettled` for partial-failure resilience), writes to `minigames_leaderboard_cache`. `/minigamestop` serves from cache.
- **Tests** — 34-case integration suite at `modules/mini-games/test/mini-games.test.ts` uses the real Takaro API + mock game server per the repo's testing philosophy in `AGENTS.md`. Covers every command, every cronjob, every game win path, daily cap, ban/unban, stats/leaderboard, and admin commands.

## Reviewer Guide

- **Start here**: `modules/mini-games/src/functions/mini-games-helpers.js` — the scorer prelude is imported by every command/hook/cronjob. Understand it first and the rest falls out.
- **Then**: `modules/mini-games/module.json` — the registry tying everything together.
- **Pay attention to**: The `awardPoints` cap-handling logic. It returns `cappedByDaily` (hit zero) and `clippedByDaily` (partial clip) flags. All 5 winner paths (`wordle`, `hangman`, `hotcold`, `/answer`, reaction-race hook) destructure both and append user-facing suffixes. This pattern took 3 iterations to get right — see Friction Log.
- **Pay attention to**: The sentinel values `"__status__"` for Wordle/Hangman optional arguments. Original sentinel `"status"` collided with the valid 5-letter English word STATUS. The double-underscore form can never be a real word in the bank.
- **Pay attention to**: Race handling in `onChatMessage` hook and `/answer` command. They re-read the active round and compare `startedAt` timestamps (not `answer` values — the reaction-race token pool is only 5 entries, 20% reuse chance) before clearing. The "two simultaneous correct answers" race is documented in the plan as an accepted known limitation (Takaro variables have no CAS).
- **Design decision**: Content banks (`minigames_content_wordle`, `minigames_content_wordlist`, `minigames_content_trivia`) live in **module variables**, not `userConfig`. Admins paste large banks via the Takaro UI Variables tab or MCP; keeps config schema tiny; avoids re-version churn when admins edit word lists. Lazy-created empty on first access.
- **Design decision**: Daily cap CLIPS rewards but does NOT block play. Once capped, players still see puzzles and live rounds; their win messages say "Daily point cap reached — no points awarded" or "Daily cap clipped reward to X points." Wins still increment stats (just with `actualPoints = 0`). This implements the plan's intent at line 162 exactly.
- **Design decision**: Trivia answers use strict normalised-exact-match. "4" and "four" don't unify. Accepted as intentional per plan.

## Testing Plan

### Happy Path
- [ ] Seed `minigames_content_wordle.words` with 20+ 5-letter words and `minigames_content_wordlist.words` with 20+ words via the Takaro UI Variables tab.
- [ ] Trigger `rolloverDailyPuzzles` cronjob; verify `minigames_puzzle_today` populated.
- [ ] `/wordle` (no arg) shows "you haven't guessed yet"; `/wordle crane` gives feedback line; `/wordle <today's answer>` shows "SOLVED in N! +X points. Streak: 1 🔥".
- [ ] `/hangman e` reveals E positions; `/hangman <full word>` solves with points.
- [ ] `/hotcold 500` shows higher/lower/warmer/colder feedback; `/hotcold <secret>` solves.
- [ ] Force `/minigamesfirenow mathrace` — chat shows `➗ MATH: …`; `/answer <number>` wins.
- [ ] Let `fireLiveRound` run automatically (wait `liveRoundIntervalMinutes`) — random live game picked and announced.
- [ ] `/minigamestats` shows lifetime stats. `/minigamestop points` shows cached top-10.

### Edge Cases
- [ ] **Sentinel collision regression**: `/wordle __status__` should be rejected as "not in bank" (not treated as status-screen request).
- [ ] **Cap clip UX**: set `dailyPointsCapPerPlayer: 10`, solve a Wordle worth 100+ points. Win message should say "Daily cap clipped reward to 10 points" on first solve, then "Daily point cap reached — no points awarded" on subsequent wins. Player should still be able to play (not blocked).
- [ ] **Boost tier**: grant `MINIGAMES_BOOST` count=2 to a role, solve Wordle, verify points = round(base × 1.5).
- [ ] **Reaction race same-token reuse**: force two consecutive reaction rounds via `/minigamesfirenow reactionrace` (token pool is only 5 entries). First-to-type should win each round independently, even if the same token repeats.
- [ ] **Multi-server name resolution** (if applicable): on multi-server installs, `/minigamestats <name>` should only return stats from the current server's player record (not another server's same-name player).
- [ ] **Admin feedback on empty bank**: run `/minigamesfirenow scramble` with empty `minigames_content_wordlist.words`. Admin should receive a PM explaining the failure. Running it again the same day should also PM (not just the deduplicated global chat warning).
- [ ] **Leaderboard names**: after `/minigamestats` and a few wins, trigger `refreshLeaderboards` cronjob. `/minigamestop points` should show actual player names, not UUIDs.
- [ ] **OpenTDB fallback**: simulate OpenTDB failure (e.g., bad category ID in config) and verify trivia falls back to `minigames_content_trivia.questions` silently.

### Regression Checks
- [ ] Existing modules unaffected — run `npm test` for the full suite (not just `modules/mini-games`).
- [ ] Banning a player (`/minigamesban testuser 1`) prevents them from winning any game; after 1h, `expireBans` cronjob clears the ban.
- [ ] Uninstalling and reinstalling the module preserves existing stats variables (permanent storage per plan).

## Implementation Journey

Completed in 8 turns (of 25 budget), severity threshold 3. 27 distinct issues identified and fixed.

| Turn | Phase | Summary | Outcome |
|------|-------|---------|---------|
| 1 | Verify | Ships 25 files implementing full plan (7 games, 14 commands, 2 hooks, 6 cronjobs, scorer prelude, 34-case test suite) | Flaky test run reported 15/34; actual state passed 34/34 on rerun |
| 2 | Verify | Full review pass (reviewer + codex) | 14 sev-3+ findings across design, architecture, hardening |
| 3 | Verify | Player addresses 11 issues: eligibility-first in hook, cap no longer throws, sentinel change, fireLiveRound helper, batched name resolution, etc. | Cap fix introduced 5 new issues |
| 4 | Verify | Player fixes cap-handling regressions (wins always increment, `cappedByDaily` flag, message suffixes) + 3 sev-1-2 items | Missed `/answer` + introduced silent admin failure on `minigamesfirenow` |
| 5 | Verify | Player fixes `/answer` cap display, switches to `pog.pm`, `startedAt` comparison for reaction race, partial-cap `clippedByDaily`, chunked leaderboard search | 1 remaining sev-4 (Promise.all) |
| 6 | Verify | Player: `Promise.allSettled` in leaderboard refresh | 1 remaining novel issue from codex |
| 7 | Verify | Player: `findPlayerByName` now validates POG on target gameServer | 1 remaining cosmetic sev-3 |
| 8 | Verify | Player fixes `/puzzle` statusLabel to accept `maxGuesses` (Wordle=6, Hangman=6, Hot/Cold=8) | **NO NEW ISSUES — APPROVED** |

## Friction Log

- **Test suite flakiness** — `modules/mini-games/test/mini-games.test.ts` exhibits intermittent failures on cold runs (observed 2–19 different tests failing across runs) that reliably resolve on rerun. Most common offenders: `rolloverDailyPuzzles` (409 conflict on `minigames_puzzle_today` write), `fireLiveRound` cronjob tests (round variable not visible after trigger), `refreshLeaderboards` (stale cron state), `minigamesresetstats`/`minigamesreport` (admin permission inheritance after mid-suite reinstall). Root cause: the daily-cap test uninstalls/reinstalls the module mid-suite, and test cleanup between tests doesn't purge all variables. Observed on every verification run across all 8 turns. **Worth a dedicated follow-up to stabilise the test suite** — the module itself passes 34/34 consistently on rerun.
- **Cap handling required two iterations** (`functions/mini-games-helpers.js`): turn 3's VI-2 fix made `checkBanAndCap` return `{remainingToday: 0}` instead of throwing, but then `awardPoints`' early-return on `actualPoints <= 0` skipped `wins++`, `totalPoints`, and `biggestScore` — creating a silent "+0 points" UX with unused stats. Turn 4 refactored to always increment wins and added the `cappedByDaily`/`clippedByDaily` flags with per-caller suffixes.
- **`/answer` missed in the cap-display fix** (`commands/answer/index.js`): turn 4's VI-16 fix updated 4 of 5 winner paths but missed `/answer` (which handles trivia/scramble/mathrace — 3 of 7 games). Turn 5 caught and corrected.
- **`minigamesfirenow` UX regression** (`commands/minigamesfirenow/index.js`): turn 4's "remove double notification" cleanup replaced a `TakaroUserError` throw with `console.log`, leaving admins with zero feedback after the daily chat warning had deduplicated. Turn 5 fixed by switching to `pog.pm` for admin-only personal feedback.
- **Race conditions around live-round clearing** (`hooks/on-chat-message/index.js`, `commands/answer/index.js`): the ordering fixes reshuffled validate → award → clear to prevent banned/capped players from griefing rounds. The `startedAt` re-read-before-clear check handles the 20% same-token-reuse false-positive risk in reaction race. The underlying "two concurrent correct answers" race remains an accepted known limitation per plan.

## Below-Threshold Issues (not fixed; accepted)

- **(sev 3) Trivia number-words mismatch** — `normaliseAnswer` exact-matches so "4" and "four" don't unify. Accepted as intentional strict-match per plan.
- **(sev 2) `recordPlay` + `awardPoints` perform two read-modify-write cycles on `minigames_stats:{playerId}`** — two API round-trips per win. Could be merged into a single RMW to halve latency and narrow inconsistency window. Deferred: refactor touches 6 files; risk-weighted not worth the churn. Tracked as potential follow-up.