### PR TITLE
Add utils module: cross-game baseline commands (issue #22)

### DIFF
--- a/modules/utils/module.json
+++ b/modules/utils/module.json
@@ -1,0 +1,209 @@
+{
+  "name": "test-utils",
+  "description": "Cross-game utility commands for server info, rules, moderation, and simple economy administration.",
+  "version": "latest",
+  "supportedGames": [
+    "all"
+  ],
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "discordLink": {
+        "type": "string",
+        "default": "",
+        "maxLength": 500,
+        "description": "Discord invite or community link shown by /discord"
+      },
+      "rules": {
+        "type": "array",
+        "default": [],
+        "maxItems": 20,
+        "description": "Server rules shown by /rules",
+        "items": {
+          "type": "string",
+          "maxLength": 200
+        }
+      },
+      "serverInfoMessage": {
+        "type": "string",
+        "default": "",
+        "maxLength": 300,
+        "description": "Optional extra server info line shown by /serverinfo"
+      },
+      "broadcastCurrencyGrants": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether /givecurrency should broadcast to the whole server"
+      },
+      "currencyGrantBroadcastMessage": {
+        "type": "string",
+        "default": "{player} received {amount} currency from {admin}.",
+        "maxLength": 300,
+        "description": "Broadcast template for /givecurrency. Supports {player}, {amount}, and {admin}."
+      },
+      "broadcastKicks": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether /kick should broadcast to the whole server"
+      },
+      "kickBroadcastMessage": {
+        "type": "string",
+        "default": "{player} was kicked by {admin}. Reason: {reason}",
+        "maxLength": 300,
+        "description": "Broadcast template for /kick. Supports {player}, {reason}, and {admin}."
+      },
+      "broadcastBans": {
+        "type": "boolean",
+        "default": false,
+        "description": "Whether /ban should broadcast to the whole server"
+      },
+      "banBroadcastMessage": {
+        "type": "string",
+        "default": "{player} was banned by {admin} for {duration}. Reason: {reason}",
+        "maxLength": 300,
+        "description": "Broadcast template for temporary /ban. Supports {player}, {reason}, {admin}, and {duration}."
+      },
+      "banPermBroadcastMessage": {
+        "type": "string",
+        "default": "{player} was permanently banned by {admin}. Reason: {reason}",
+        "maxLength": 300,
+        "description": "Broadcast template for permanent /ban. Supports {player}, {reason}, and {admin}."
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "uiSchema": {},
+  "permissions": [
+    {
+      "canHaveCount": false,
+      "description": "Allows a player to kick other players",
+      "permission": "UTILS_KICK",
+      "friendlyName": "Kick Players"
+    },
+    {
+      "canHaveCount": false,
+      "description": "Allows a player to ban other players",
+      "permission": "UTILS_BAN",
+      "friendlyName": "Ban Players"
+    },
+    {
+      "canHaveCount": false,
+      "description": "Allows a player to grant currency to players",
+      "permission": "UTILS_GIVE_CURRENCY",
+      "friendlyName": "Give Currency"
+    }
+  ],
+  "commands": {
+    "serverinfo": {
+      "trigger": "serverinfo",
+      "description": "Show basic server information",
+      "helpText": "Shows the server name, online player count, and optional server info message.",
+      "function": "src/commands/serverinfo/index.js",
+      "arguments": []
+    },
+    "online": {
+      "trigger": "online",
+      "description": "Show online players",
+      "helpText": "Shows how many players are online and lists up to 10 names.",
+      "function": "src/commands/online/index.js",
+      "arguments": []
+    },
+    "discord": {
+      "trigger": "discord",
+      "description": "Show the server Discord link",
+      "helpText": "Shows the configured Discord link for this server.",
+      "function": "src/commands/discord/index.js",
+      "arguments": []
+    },
+    "rules": {
+      "trigger": "rules",
+      "description": "Show server rules",
+      "helpText": "Shows the configured server rules as a numbered list.",
+      "function": "src/commands/rules/index.js",
+      "arguments": []
+    },
+    "kick": {
+      "trigger": "kick",
+      "description": "Kick an online player",
+      "helpText": "Usage: kick <player> [reason] — kicks a player from the server.",
+      "function": "src/commands/kick/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "player",
+          "defaultValue": null,
+          "helpText": "The player to kick",
+          "position": 0
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "defaultValue": "?",
+          "helpText": "Optional reason shown to the target and in broadcasts",
+          "position": 1
+        }
+      ]
+    },
+    "ban": {
+      "trigger": "ban",
+      "description": "Ban a player temporarily or permanently",
+      "helpText": "Usage: ban <player> <duration> [reason] — duration: perm/permanent or 10m, 12h, 7d, 2w.",
+      "function": "src/commands/ban/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "player",
+          "defaultValue": null,
+          "helpText": "The player to ban",
+          "position": 0
+        },
+        {
+          "name": "duration",
+          "type": "string",
+          "defaultValue": null,
+          "helpText": "perm/permanent or a value like 10m, 12h, 7d, or 2w",
+          "position": 1
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "defaultValue": "?",
+          "helpText": "Optional reason shown in the ban confirmation and broadcasts",
+          "position": 2
+        }
+      ]
+    },
+    "givecurrency": {
+      "trigger": "givecurrency",
+      "description": "Grant currency to a player",
+      "helpText": "Usage: givecurrency <player> <amount> — amount must be a positive whole number.",
+      "function": "src/commands/givecurrency/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "player",
+          "defaultValue": null,
+          "helpText": "The player to receive currency",
+          "position": 0
+        },
+        {
+          "name": "amount",
+          "type": "number",
+          "defaultValue": null,
+          "helpText": "Amount of currency to give (positive whole number)",
+          "position": 1
+        }
+      ]
+    }
+  },
+  "functions": {
+    "utils-helpers": {
+      "function": "src/functions/utils-helpers.js"
+    },
+    "utils-pure": {
+      "function": "src/functions/utils-pure.js"
+    }
+  }
+}

--- a/modules/utils/src/commands/ban/index.js
+++ b/modules/utils/src/commands/ban/index.js
@@ -1,0 +1,91 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getCommandTargetPlayer,
+  normalizeReason,
+  parseBanDurationToken,
+  renderTemplate,
+} from './utils-pure.js';
+import {
+  getPlayerName,
+  safeBroadcast,
+} from './utils-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'UTILS_BAN')) {
+    throw new TakaroUserError('You do not have permission to use this command.');
+  }
+
+  const target = getCommandTargetPlayer(args.player);
+  if (!target) {
+    throw new TakaroUserError('Please specify a valid player to ban.');
+  }
+
+  if (target.playerId === player.id) {
+    throw new TakaroUserError('You cannot use this command on yourself.');
+  }
+
+  const parsedDuration = parseBanDurationToken(args.duration);
+  if (!parsedDuration) {
+    throw new TakaroUserError('Invalid duration. Use perm/permanent or a value like 10m, 12h, 7d, or 2w.');
+  }
+
+  const [adminName, targetName] = await Promise.all([
+    getPlayerName(player.id, player.name),
+    getPlayerName(target.playerId, target.name),
+  ]);
+  const reason = normalizeReason(args.reason, 'Banned by an admin.');
+
+  const payload = {
+    reason,
+  };
+  if (!parsedDuration.isPermanent) {
+    payload.expiresAt = parsedDuration.expiresAt;
+  }
+
+  console.log(`utils:ban payload=${JSON.stringify(payload)}`);
+
+  try {
+    await takaro.gameserver.gameServerControllerBanPlayer(gameServerId, target.playerId, payload);
+  } catch (err) {
+    console.error(`utils:ban failed for target=${target.playerId}: ${err}`);
+    throw new TakaroUserError('The ban could not be created right now. Please try again in a moment.');
+  }
+
+  console.log(`utils:ban admin=${adminName} target=${targetName} duration=${parsedDuration.humanDuration} reason=${reason}`);
+
+  const confirmationMessage = parsedDuration.isPermanent
+    ? `Banned ${targetName} permanently. Reason: ${reason}`
+    : `Banned ${targetName} for ${parsedDuration.humanDuration}. Reason: ${reason}`;
+
+  console.log(`utils:ban pm=${confirmationMessage}`);
+  try {
+    await pog.pm(confirmationMessage);
+  } catch (err) {
+    console.error(`utils:ban pm failed: ${err}`);
+  }
+
+  if (mod.userConfig.broadcastBans) {
+    // Use separate templates for perm vs temp to avoid "for permanently" grammar issue
+    let message;
+    if (parsedDuration.isPermanent) {
+      const permTemplate = mod.userConfig.banPermBroadcastMessage || '{player} was permanently banned by {admin}. Reason: {reason}';
+      message = renderTemplate(permTemplate, {
+        player: targetName,
+        reason,
+        admin: adminName,
+      });
+    } else {
+      message = renderTemplate(mod.userConfig.banBroadcastMessage, {
+        player: targetName,
+        reason,
+        admin: adminName,
+        duration: parsedDuration.humanDuration,
+      });
+    }
+    await safeBroadcast(gameServerId, message);
+  }
+}
+
+await main();

--- a/modules/utils/src/commands/discord/index.js
+++ b/modules/utils/src/commands/discord/index.js
@@ -1,0 +1,22 @@
+import { data } from '@takaro/helpers';
+import { trimOrEmpty } from './utils-pure.js';
+
+async function main() {
+  const { pog, module: mod } = data;
+  const discordLink = trimOrEmpty(mod.userConfig.discordLink);
+
+  if (discordLink === '') {
+    const message = 'This server has not configured a Discord link.';
+    console.log(`utils:discord unconfigured`);
+    console.log(message);
+    await pog.pm(message);
+    return;
+  }
+
+  const message = `Join our Discord: ${discordLink}`;
+  console.log(`utils:discord ${discordLink}`);
+  console.log(message);
+  await pog.pm(message);
+}
+
+await main();

--- a/modules/utils/src/commands/givecurrency/index.js
+++ b/modules/utils/src/commands/givecurrency/index.js
@@ -1,0 +1,61 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getCommandTargetPlayer,
+  renderTemplate,
+} from './utils-pure.js';
+import {
+  getPlayerName,
+  safeBroadcast,
+} from './utils-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'UTILS_GIVE_CURRENCY')) {
+    throw new TakaroUserError('You do not have permission to use this command.');
+  }
+
+  const amount = args.amount;
+
+  const target = getCommandTargetPlayer(args.player);
+  if (!target) {
+    throw new TakaroUserError('Please specify a valid player to receive currency.');
+  }
+
+  if (!Number.isInteger(amount) || amount <= 0) {
+    throw new TakaroUserError('Usage: givecurrency <player> <amount> — Amount must be a positive whole number.');
+  }
+
+  const [adminName, targetName] = await Promise.all([
+    getPlayerName(player.id, player.name),
+    getPlayerName(target.playerId, target.name),
+  ]);
+
+  try {
+    await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, target.playerId, {
+      currency: amount,
+    });
+  } catch (err) {
+    console.error(`utils:givecurrency failed for target=${target.playerId} amount=${amount}: ${err}`);
+    throw new TakaroUserError('The currency grant could not be completed. Please try again in a moment. If it keeps failing, contact a server owner.');
+  }
+
+  console.log(`utils:givecurrency admin=${adminName} target=${targetName} amount=${amount}`);
+
+  try {
+    await pog.pm(`Gave ${amount} currency to ${targetName}.`);
+  } catch (err) {
+    console.error(`utils:givecurrency pm failed: ${err}`);
+  }
+
+  if (mod.userConfig.broadcastCurrencyGrants) {
+    const message = renderTemplate(mod.userConfig.currencyGrantBroadcastMessage, {
+      player: targetName,
+      amount,
+      admin: adminName,
+    });
+    await safeBroadcast(gameServerId, message);
+  }
+}
+
+await main();

--- a/modules/utils/src/commands/kick/index.js
+++ b/modules/utils/src/commands/kick/index.js
@@ -1,0 +1,67 @@
+import { data, takaro, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getCommandTargetPlayer,
+  normalizeReason,
+  renderTemplate,
+} from './utils-pure.js';
+import {
+  getPlayerName,
+  safeBroadcast,
+} from './utils-helpers.js';
+
+async function main() {
+  const { pog, player, gameServerId, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'UTILS_KICK')) {
+    throw new TakaroUserError('You do not have permission to use this command.');
+  }
+
+  const target = getCommandTargetPlayer(args.player);
+  if (!target) {
+    throw new TakaroUserError('Please specify a valid player to kick.');
+  }
+
+  if (!target.online) {
+    throw new TakaroUserError('That player is not currently online.');
+  }
+
+  if (target.playerId === player.id) {
+    throw new TakaroUserError('You cannot use this command on yourself.');
+  }
+
+  const [adminName, targetName] = await Promise.all([
+    getPlayerName(player.id, player.name),
+    getPlayerName(target.playerId, target.name),
+  ]);
+  const reason = normalizeReason(args.reason, 'Kicked by an admin.');
+
+  try {
+    await takaro.gameserver.gameServerControllerKickPlayer(gameServerId, target.playerId, {
+      reason,
+    });
+  } catch (err) {
+    console.error(`utils:kick failed for target=${target.playerId}: ${err}`);
+    throw new TakaroUserError('That player could not be kicked right now. They may have just disconnected, or the game server rejected the kick.');
+  }
+
+  console.log(`utils:kick admin=${adminName} target=${targetName} reason=${reason}`);
+
+  const kickPm = `Kicked ${targetName}. Reason: ${reason}`;
+  console.log(`utils:kick pm=${kickPm}`);
+  try {
+    await pog.pm(kickPm);
+  } catch (err) {
+    console.error(`utils:kick pm failed: ${err}`);
+  }
+
+  if (mod.userConfig.broadcastKicks) {
+    const message = renderTemplate(mod.userConfig.kickBroadcastMessage, {
+      player: targetName,
+      reason,
+      admin: adminName,
+    });
+    await safeBroadcast(gameServerId, message);
+  }
+}
+
+await main();

--- a/modules/utils/src/commands/online/index.js
+++ b/modules/utils/src/commands/online/index.js
@@ -1,0 +1,13 @@
+import { data } from '@takaro/helpers';
+import { formatOnlinePlayersLine } from './utils-pure.js';
+import { fetchOnlinePlayers } from './utils-helpers.js';
+
+async function main() {
+  const { gameServerId, pog } = data;
+  const onlinePlayers = await fetchOnlinePlayers(gameServerId);
+  const message = formatOnlinePlayersLine(onlinePlayers);
+  console.log(`utils:online ${message}`);
+  await pog.pm(message);
+}
+
+await main();

--- a/modules/utils/src/commands/rules/index.js
+++ b/modules/utils/src/commands/rules/index.js
@@ -1,0 +1,27 @@
+import { data } from '@takaro/helpers';
+import { compactRules } from './utils-pure.js';
+
+async function main() {
+  const { pog, module: mod } = data;
+  const rules = compactRules(mod.userConfig.rules);
+
+  if (rules.length === 0) {
+    const message = 'This server has not configured any rules yet.';
+    console.log(`utils:rules unconfigured`);
+    console.log(message);
+    await pog.pm(message);
+    return;
+  }
+
+  const lines = ['Server rules:'];
+  for (let i = 0; i < rules.length; i++) {
+    lines.push(`${i + 1}. ${rules[i]}`);
+  }
+
+  const message = lines.join('\n');
+  console.log(`utils:rules ${rules.length} rules`);
+  console.log(message);
+  await pog.pm(message);
+}
+
+await main();

--- a/modules/utils/src/commands/serverinfo/index.js
+++ b/modules/utils/src/commands/serverinfo/index.js
@@ -1,0 +1,27 @@
+import { data } from '@takaro/helpers';
+import { trimOrEmpty } from './utils-pure.js';
+import { fetchOnlinePlayers, getGameServerName } from './utils-helpers.js';
+
+async function main() {
+  const { gameServerId, pog, module: mod } = data;
+  const [serverName, onlinePlayers] = await Promise.all([
+    getGameServerName(gameServerId),
+    fetchOnlinePlayers(gameServerId),
+  ]);
+
+  const lines = [
+    `Server: ${serverName}`,
+    `Players online: ${onlinePlayers.length}`,
+  ];
+
+  const infoMessage = trimOrEmpty(mod.userConfig.serverInfoMessage);
+  if (infoMessage !== '') {
+    lines.push(`Info: ${infoMessage}`);
+  }
+
+  const message = lines.join('\n');
+  console.log(`utils:serverinfo ${message}`);
+  await pog.pm(message);
+}
+
+await main();

--- a/modules/utils/src/functions/utils-helpers.js
+++ b/modules/utils/src/functions/utils-helpers.js
@@ -1,0 +1,104 @@
+import { takaro } from '@takaro/helpers';
+
+function trimOrEmptyInternal(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return '';
+  return String(value).trim();
+}
+
+function collapsePlayersById(players) {
+  const seen = new Set();
+  const uniquePlayers = [];
+
+  for (const player of players) {
+    const playerId = String(player?.playerId || player?.id || '').trim();
+    if (playerId === '' || seen.has(playerId)) continue;
+    seen.add(playerId);
+    uniquePlayers.push(player);
+  }
+
+  return uniquePlayers;
+}
+
+async function collectPaginatedResults(fetchPage, { limit = 100, maxIterations = 100 } = {}) {
+  const items = [];
+
+  for (let page = 0; page < maxIterations; page += 1) {
+    const result = await fetchPage({ page, limit });
+    const batch = Array.isArray(result?.data) ? result.data : [];
+    const total = typeof result?.total === 'number' ? result.total : undefined;
+
+    items.push(...batch);
+
+    if (batch.length === 0) return items;
+    if (total !== undefined && items.length >= total) return items;
+    if (batch.length < limit && total === undefined) return items;
+  }
+
+  throw new Error(
+    `collectPaginatedResults reached the ${maxIterations}-page safety limit before pagination completed.`,
+  );
+}
+
+export async function fetchOnlinePlayers(gameServerId) {
+  const players = await collectPaginatedResults(async ({ page, limit }) => {
+    const result = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: {
+        gameServerId: [gameServerId],
+        online: [true],
+      },
+      page,
+      limit,
+    });
+
+    return {
+      data: result.data.data,
+      total: result.data.meta?.total,
+    };
+  }, { limit: 100, maxIterations: 1000 });
+
+  const uniquePlayers = collapsePlayersById(players);
+  const namedPlayers = await Promise.all(uniquePlayers.map(async (player) => ({
+    ...player,
+    name: await getPlayerName(player.playerId, ''),
+  })));
+
+  return namedPlayers;
+}
+
+export async function getGameServerName(gameServerId) {
+  try {
+    const result = await takaro.gameserver.gameServerControllerGetOne(gameServerId);
+    const trimmed = trimOrEmptyInternal(result?.data?.data?.name);
+    return trimmed || 'Unknown Server';
+  } catch (err) {
+    console.error(`utils-helpers: failed to load gameserver ${gameServerId}: ${err}`);
+    return 'Unknown Server';
+  }
+}
+
+export async function getPlayerName(playerId, fallback) {
+  try {
+    const result = await takaro.player.playerControllerGetOne(playerId);
+    const trimmed = trimOrEmptyInternal(result?.data?.data?.name);
+    return trimmed || fallback || 'Unknown Player';
+  } catch (err) {
+    console.error(`utils-helpers: failed to load player ${playerId}: ${err}`);
+    return fallback || 'Unknown Player';
+  }
+}
+
+export async function safeBroadcast(gameServerId, message) {
+  const trimmed = trimOrEmptyInternal(message);
+  if (trimmed === '') return false;
+  try {
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: trimmed,
+      opts: {},
+    });
+    console.log(`[broadcast] ${trimmed}`);
+    return true;
+  } catch (err) {
+    console.error(`utils-helpers: broadcast failed: ${err}`);
+    return false;
+  }
+}

--- a/modules/utils/src/functions/utils-pure.d.ts
+++ b/modules/utils/src/functions/utils-pure.d.ts
@@ -1,0 +1,19 @@
+export function isBlank(value: unknown): boolean;
+export function trimOrEmpty(value: unknown): string;
+export function normalizeReason(value: unknown, fallback: string): string;
+export function compactRules(rules: unknown): string[];
+export function formatOnlinePlayersLine(players: Array<{ name?: unknown; playerName?: unknown }>): string;
+export function getCommandTargetPlayer(target: unknown): {
+  playerId: string;
+  name: string;
+  gameId: string;
+  gameServerId: string;
+  online: unknown;
+} | null;
+export function renderTemplate(template: unknown, placeholders: Record<string, unknown>): string;
+export function parseBanDurationToken(token: unknown): {
+  isPermanent: boolean;
+  expiresAt?: string;
+  humanDuration: string;
+  normalizedToken: string;
+} | null;

--- a/modules/utils/src/functions/utils-pure.js
+++ b/modules/utils/src/functions/utils-pure.js
@@ -1,0 +1,112 @@
+/**
+ * Pure utility functions with no @takaro/helpers dependency.
+ * These can be imported in tests without the Takaro sandbox.
+ */
+
+export function isBlank(value) {
+  return value === undefined || value === null || String(value).trim() === '';
+}
+
+export function trimOrEmpty(value) {
+  return isBlank(value) ? '' : String(value).trim();
+}
+
+export function normalizeReason(value, fallback) {
+  const trimmed = trimOrEmpty(value);
+  return trimmed === '' || trimmed === '?' ? fallback : trimmed;
+}
+
+export function compactRules(rules) {
+  if (!Array.isArray(rules)) return [];
+  return rules
+    .map((rule) => trimOrEmpty(rule))
+    .filter((rule) => rule !== '');
+}
+
+export function formatOnlinePlayersLine(players) {
+  const names = players
+    .map((player) => trimOrEmpty(player.name || player.playerName))
+    .filter((name) => name !== '')
+    .sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+
+  if (names.length === 0) {
+    return 'No players are currently online.';
+  }
+
+  const visible = names.slice(0, 10);
+  const hiddenCount = Math.max(0, names.length - visible.length);
+  const suffix = hiddenCount > 0 ? ', ...' : '';
+  const noun = names.length === 1 ? 'player' : 'players';
+  return `${names.length} ${noun} online: ${visible.join(', ')}${suffix}`;
+}
+
+export function getCommandTargetPlayer(target) {
+  if (!target || typeof target !== 'object') return null;
+
+  const playerId = trimOrEmpty(target.playerId || target.id);
+  if (playerId === '') return null;
+
+  return {
+    playerId,
+    name: trimOrEmpty(target.name || target.playerName) || 'Unknown Player',
+    gameId: trimOrEmpty(target.gameId),
+    gameServerId: trimOrEmpty(target.gameServerId),
+    online: target.online,
+  };
+}
+
+export function renderTemplate(template, placeholders) {
+  const source = trimOrEmpty(template);
+  return source.replace(/\{([a-zA-Z0-9_]+)\}/g, (_, key) => {
+    if (Object.prototype.hasOwnProperty.call(placeholders, key)) {
+      return String(placeholders[key]);
+    }
+    return `{${key}}`;
+  });
+}
+
+/**
+ * Parse a ban duration token such as "perm", "permanent", "10m", "12h", "7d", "2w".
+ * Returns a parsed duration object or null if invalid.
+ */
+export function parseBanDurationToken(token) {
+  const normalized = trimOrEmpty(token).toLowerCase();
+
+  if (normalized === 'perm' || normalized === 'permanent') {
+    return {
+      isPermanent: true,
+      expiresAt: undefined,
+      humanDuration: 'permanent',
+      normalizedToken: normalized,
+    };
+  }
+
+  const match = normalized.match(/^(\d+)([mhdw])$/);
+  if (!match) return null;
+
+  const amount = Number(match[1]);
+  const unit = match[2];
+  if (!Number.isInteger(amount) || amount <= 0) return null;
+
+  const unitConfig = {
+    m: { ms: 60 * 1000, singular: 'minute', plural: 'minutes' },
+    h: { ms: 60 * 60 * 1000, singular: 'hour', plural: 'hours' },
+    d: { ms: 24 * 60 * 60 * 1000, singular: 'day', plural: 'days' },
+    w: { ms: 7 * 24 * 60 * 60 * 1000, singular: 'week', plural: 'weeks' },
+  }[unit];
+
+  if (!unitConfig) return null;
+
+  const durationMs = amount * unitConfig.ms;
+  const expiresAtMs = Date.now() + durationMs;
+  if (!Number.isSafeInteger(durationMs) || !Number.isFinite(expiresAtMs) || expiresAtMs > 8.64e15) {
+    return null;
+  }
+
+  return {
+    isPermanent: false,
+    expiresAt: new Date(expiresAtMs).toISOString(),
+    humanDuration: `${amount} ${amount === 1 ? unitConfig.singular : unitConfig.plural}`,
+    normalizedToken: normalized,
+  };
+}

--- a/modules/utils/test/utils.test.ts
+++ b/modules/utils/test/utils.test.ts
@@ -1,0 +1,1245 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+import {
+  isBlank,
+  trimOrEmpty,
+  normalizeReason,
+  compactRules,
+  formatOnlinePlayersLine,
+  getCommandTargetPlayer,
+  renderTemplate,
+  parseBanDurationToken,
+} from '../src/functions/utils-pure.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+// Helpers -------------------------------------------------------------------
+
+type CommandMeta = { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+
+async function fetchPlayerName(client: Client, playerId: string): Promise<string> {
+  const result = await client.player.playerControllerGetOne(playerId);
+  return result.data.data.name;
+}
+
+async function triggerCommand(
+  client: Client,
+  ctx: MockServerContext,
+  prefix: string,
+  msg: string,
+  playerId: string,
+): Promise<{ success: boolean; logs: string[] }> {
+  const startTime = new Date();
+
+  await client.command.commandControllerTrigger(ctx.gameServer.id, {
+    msg: `${prefix}${msg}`,
+    playerId,
+  });
+
+  const event = await waitForEvent(client, {
+    eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+    gameserverId: ctx.gameServer.id,
+    after: startTime,
+    timeout: 30000,
+  });
+
+  const meta = event.meta as CommandMeta;
+  const success = meta?.result?.success ?? false;
+  const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+  return { success, logs };
+}
+
+// Pure helpers live in utils-pure.js and are the single source of truth.
+// Commands import pure helpers from ./utils-pure.js (Takaro-dependent helpers from ./utils-helpers.js).
+// Tests import from ../src/functions/utils-pure.js directly — same code that runs in production.
+
+describe('utils: formatOnlinePlayersLine unit behavior', () => {
+  it('returns no-players message for empty list', () => {
+    assert.equal(formatOnlinePlayersLine([]), 'No players are currently online.');
+  });
+
+  it('uses singular "player" for exactly one player', () => {
+    const result = formatOnlinePlayersLine([{ name: 'Alice' }]);
+    assert.equal(result, '1 player online: Alice');
+  });
+
+  it('sorts names alphabetically (case-insensitive)', () => {
+    const result = formatOnlinePlayersLine([
+      { name: 'Zara' },
+      { name: 'alice' },
+      { name: 'Bob' },
+    ]);
+    assert.ok(result.startsWith('3 players online: alice, Bob, Zara'), `Got: ${result}`);
+  });
+
+  it('shows up to 10 names without truncation for exactly 10 players', () => {
+    const players = Array.from({ length: 10 }, (_, i) => ({ name: `Player${String(i).padStart(2, '0')}` }));
+    const result = formatOnlinePlayersLine(players);
+    assert.ok(!result.includes('...'), `Expected no truncation for 10 players, got: ${result}`);
+    assert.ok(result.startsWith('10 players online:'), `Got: ${result}`);
+  });
+
+  it('truncates with "..." for more than 10 players', () => {
+    const players = Array.from({ length: 11 }, (_, i) => ({ name: `Player${String(i).padStart(2, '0')}` }));
+    const result = formatOnlinePlayersLine(players);
+    assert.ok(result.includes('...'), `Expected truncation for 11 players, got: ${result}`);
+    assert.ok(result.startsWith('11 players online:'), `Got: ${result}`);
+  });
+
+  it('shows total count even when truncated (27 players example)', () => {
+    const players = Array.from({ length: 27 }, (_, i) => ({ name: `Player${String(i).padStart(2, '0')}` }));
+    const result = formatOnlinePlayersLine(players);
+    assert.ok(result.startsWith('27 players online:'), `Got: ${result}`);
+    assert.ok(result.endsWith(', ...'), `Expected ", ..." at end, got: ${result}`);
+  });
+});
+
+describe('utils: parseBanDurationToken unit behavior', () => {
+  it('"perm" is permanent', () => {
+    const result = parseBanDurationToken('perm');
+    assert.ok(result !== null);
+    assert.equal(result!.isPermanent, true);
+    assert.equal(result!.humanDuration, 'permanent');
+    assert.equal(result!.expiresAt, undefined);
+  });
+
+  it('"permanent" is permanent', () => {
+    const result = parseBanDurationToken('permanent');
+    assert.ok(result !== null);
+    assert.equal(result!.isPermanent, true);
+  });
+
+  it('1m renders as "1 minute" (singular)', () => {
+    const result = parseBanDurationToken('1m');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '1 minute');
+    assert.equal(result!.isPermanent, false);
+    assert.ok(result!.expiresAt !== undefined);
+  });
+
+  it('2m renders as "2 minutes" (plural)', () => {
+    const result = parseBanDurationToken('2m');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '2 minutes');
+  });
+
+  it('1d renders as "1 day" (singular)', () => {
+    const result = parseBanDurationToken('1d');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '1 day');
+  });
+
+  it('7d renders as "7 days" (plural)', () => {
+    const result = parseBanDurationToken('7d');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '7 days');
+  });
+
+  it('1w renders as "1 week" (singular)', () => {
+    const result = parseBanDurationToken('1w');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '1 week');
+  });
+
+  it('2w renders as "2 weeks" (plural)', () => {
+    const result = parseBanDurationToken('2w');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '2 weeks');
+  });
+
+  it('12h renders as "12 hours"', () => {
+    const result = parseBanDurationToken('12h');
+    assert.ok(result !== null);
+    assert.equal(result!.humanDuration, '12 hours');
+  });
+
+  it('invalid token returns null', () => {
+    assert.equal(parseBanDurationToken('invalid-duration'), null);
+    assert.equal(parseBanDurationToken('0m'), null);
+    assert.equal(parseBanDurationToken('-5h'), null);
+    assert.equal(parseBanDurationToken(''), null);
+  });
+});
+
+describe('utils: isBlank unit behavior', () => {
+  it('returns true for undefined', () => {
+    assert.equal(isBlank(undefined), true);
+  });
+
+  it('returns true for null', () => {
+    assert.equal(isBlank(null), true);
+  });
+
+  it('returns true for empty string', () => {
+    assert.equal(isBlank(''), true);
+  });
+
+  it('returns true for whitespace-only string', () => {
+    assert.equal(isBlank('   '), true);
+  });
+
+  it('returns false for a non-empty string', () => {
+    assert.equal(isBlank('hello'), false);
+  });
+
+  it('returns false for a non-string non-null value', () => {
+    assert.equal(isBlank(42), false);
+  });
+
+  it('returns false for boolean false (stringifies to "false")', () => {
+    assert.equal(isBlank(false), false);
+  });
+
+  it('returns false for numeric 0 (stringifies to "0")', () => {
+    assert.equal(isBlank(0), false);
+  });
+});
+
+describe('utils: trimOrEmpty unit behavior', () => {
+  it('returns empty string for non-string falsy value', () => {
+    assert.equal(trimOrEmpty(undefined), '');
+    assert.equal(trimOrEmpty(null), '');
+  });
+
+  it('returns trimmed string for padded string', () => {
+    assert.equal(trimOrEmpty('  hello  '), 'hello');
+  });
+
+  it('returns empty string for whitespace-only input', () => {
+    assert.equal(trimOrEmpty('   '), '');
+  });
+});
+
+describe('utils: normalizeReason unit behavior', () => {
+  it('returns fallback for sentinel "?"', () => {
+    assert.equal(normalizeReason('?', 'Default reason'), 'Default reason');
+  });
+
+  it('returns fallback for blank input', () => {
+    assert.equal(normalizeReason('', 'Default reason'), 'Default reason');
+    assert.equal(normalizeReason('   ', 'Default reason'), 'Default reason');
+  });
+
+  it('returns trimmed value when not blank or sentinel', () => {
+    assert.equal(normalizeReason('  Griefing  ', 'Default reason'), 'Griefing');
+  });
+});
+
+describe('utils: compactRules unit behavior', () => {
+  it('returns empty array for non-array input', () => {
+    assert.deepEqual(compactRules(null), []);
+    assert.deepEqual(compactRules(undefined), []);
+    assert.deepEqual(compactRules('not an array'), []);
+  });
+
+  it('filters out blank and whitespace-only entries', () => {
+    assert.deepEqual(compactRules(['', '   ', '\t']), []);
+  });
+
+  it('keeps valid entries', () => {
+    assert.deepEqual(compactRules(['No griefing', 'Be respectful']), ['No griefing', 'Be respectful']);
+  });
+
+  it('trims entries and filters blanks from mixed array', () => {
+    const result = compactRules(['  No griefing  ', '   ', 'Be respectful']);
+    assert.deepEqual(result, ['No griefing', 'Be respectful']);
+  });
+});
+
+describe('utils: getCommandTargetPlayer unit behavior', () => {
+  it('returns null for null or non-object input', () => {
+    assert.equal(getCommandTargetPlayer(null), null);
+    assert.equal(getCommandTargetPlayer('string'), null);
+    assert.equal(getCommandTargetPlayer(42), null);
+  });
+
+  it('returns null when playerId is missing or blank', () => {
+    assert.equal(getCommandTargetPlayer({}), null);
+    assert.equal(getCommandTargetPlayer({ playerId: '   ' }), null);
+  });
+
+  it('returns normalized player object with only playerId', () => {
+    const result = getCommandTargetPlayer({ playerId: 'abc-123' });
+    assert.ok(result !== null);
+    assert.equal(result!.playerId, 'abc-123');
+    assert.equal(result!.name, 'Unknown Player');
+  });
+
+  it('returns normalized player object with full shape', () => {
+    const result = getCommandTargetPlayer({
+      playerId: 'abc-123',
+      name: '  Alice  ',
+      gameId: 'g1',
+      gameServerId: 'srv1',
+      online: true,
+    });
+    assert.ok(result !== null);
+    assert.equal(result!.name, 'Alice');
+    assert.equal(result!.gameId, 'g1');
+    assert.equal(result!.online, true);
+  });
+});
+
+describe('utils: renderTemplate unit behavior', () => {
+  it('returns source unchanged when no placeholders present', () => {
+    assert.equal(renderTemplate('Hello world', {}), 'Hello world');
+  });
+
+  it('replaces all placeholders when provided', () => {
+    const result = renderTemplate('{player} got {amount} coins from {admin}', {
+      player: 'Alice',
+      amount: 100,
+      admin: 'Bob',
+    });
+    assert.equal(result, 'Alice got 100 coins from Bob');
+  });
+
+  it('keeps placeholder literal when key is missing', () => {
+    const result = renderTemplate('{player} got {amount} coins', { player: 'Alice' });
+    assert.equal(result, 'Alice got {amount} coins');
+  });
+
+  it('replaces every occurrence when placeholder appears twice', () => {
+    const result = renderTemplate('{name} and {name}', { name: 'Alice' });
+    assert.equal(result, 'Alice and Alice');
+  });
+});
+
+// Suite 1: Public commands --------------------------------------------------
+
+describe('utils: public commands', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        discordLink: 'https://discord.gg/example',
+        rules: ['No griefing', 'Be respectful', 'No cheating'],
+        serverInfoMessage: 'Welcome to our server!',
+        broadcastCurrencyGrants: false,
+        broadcastKicks: false,
+        broadcastBans: false,
+      },
+    });
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('/serverinfo shows server name and online count', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'serverinfo', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('Server:') && msg.includes('Players online:')),
+      `Expected serverinfo output with Server: and Players online:, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/serverinfo shows configured info message when set', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'serverinfo', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('Welcome to our server!')),
+      `Expected serverinfo output to include info message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/online shows player count when players are online', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'online', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('players online') || msg.includes('player online')),
+      `Expected online player list, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/online lists players in alphabetical order', async () => {
+    // ctx.players has 3 players — enough to verify alphabetical sorting
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'online', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+
+    // Find the online log line
+    const onlineLine = logs.find((msg) => msg.includes('players online') || msg.includes('player online'));
+    assert.ok(onlineLine, `Expected online line in logs, got: ${JSON.stringify(logs)}`);
+
+    // Extract the names portion (after "N players online: ")
+    const namesMatch = onlineLine!.match(/\d+ players? online: (.+)/);
+    assert.ok(namesMatch, `Expected /online output in format "N players online: ...", got: ${onlineLine}`);
+    const names = namesMatch![1].replace(', ...', '').split(', ');
+    // Verify names are in alphabetical order
+    const sorted = [...names].sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }));
+    assert.deepEqual(names, sorted, `Expected alphabetical order, got: ${names.join(', ')}`);
+  });
+
+  it('/discord shows configured link', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'discord', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('discord.gg/example')),
+      `Expected discord link in output, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/rules shows "Server rules:" header followed by numbered rules', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'rules', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    const allLogs = logs.join('\n');
+    assert.ok(
+      allLogs.includes('Server rules:'),
+      `Expected "Server rules:" header in output, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      allLogs.includes('No griefing') && allLogs.includes('Be respectful'),
+      `Expected rules in output, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/rules filters whitespace-only entries', async () => {
+    // This suite's rules config is clean, but we test that numbered list format is correct
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'rules', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    const allLogs = logs.join('\n');
+    // Should have exactly 3 numbered rules
+    assert.ok(allLogs.includes('1.'), `Expected numbered rule 1, got: ${JSON.stringify(logs)}`);
+    assert.ok(allLogs.includes('2.'), `Expected numbered rule 2, got: ${JSON.stringify(logs)}`);
+    assert.ok(allLogs.includes('3.'), `Expected numbered rule 3, got: ${JSON.stringify(logs)}`);
+  });
+});
+
+// Suite 2: Empty config fallbacks -------------------------------------------
+
+describe('utils: empty config fallbacks', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with empty config (no discord link, no rules, no serverInfoMessage)
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        discordLink: '',
+        rules: [],
+        serverInfoMessage: '',
+        broadcastCurrencyGrants: false,
+        broadcastKicks: false,
+        broadcastBans: false,
+      },
+    });
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('/discord shows unconfigured message when discord link is empty', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'discord', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('not configured')),
+      `Expected unconfigured discord message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/rules shows unconfigured message when rules are empty', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'rules', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('not configured')),
+      `Expected unconfigured rules message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/rules filters whitespace-only entries and shows unconfigured', async () => {
+    // Reinstall with whitespace rules - handled by separate context
+    // For this suite, rules=[] so we just verify the fallback
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'rules', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('not configured')),
+      `Expected unconfigured message for empty rules, got: ${JSON.stringify(logs)}`,
+    );
+    // Should NOT have numbered items
+    const allLogs = logs.join('\n');
+    assert.ok(!allLogs.includes('1.'), `Expected no numbered rules, got: ${JSON.stringify(logs)}`);
+  });
+
+  it('/serverinfo does not show info line when serverInfoMessage is empty', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'serverinfo', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    const allLogs = logs.join('\n');
+    assert.ok(
+      !allLogs.includes('Info:'),
+      `Expected no Info: line when serverInfoMessage is empty, got: ${JSON.stringify(logs)}`,
+    );
+  });
+});
+
+// Suite 2b: /rules whitespace-filter test ------------------------------------
+
+describe('utils: /rules whitespace-filter', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    // Install with rules that include whitespace-only entries (VI-14)
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        discordLink: '',
+        rules: ['No griefing', '   ', 'Be respectful', '\t'],
+        serverInfoMessage: '',
+        broadcastCurrencyGrants: false,
+        broadcastKicks: false,
+        broadcastBans: false,
+      },
+    });
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('/rules shows only non-blank entries when whitespace-only items present', async () => {
+    const player = ctx.players[0]!;
+    const { success, logs } = await triggerCommand(client, ctx, prefix, 'rules', player.playerId);
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    const allLogs = logs.join('\n');
+
+    // Should have "No griefing" and "Be respectful"
+    assert.ok(allLogs.includes('No griefing'), `Expected "No griefing" in output, got: ${JSON.stringify(logs)}`);
+    assert.ok(allLogs.includes('Be respectful'), `Expected "Be respectful" in output, got: ${JSON.stringify(logs)}`);
+
+    // Should have exactly 2 entries (1. and 2. but not 3.)
+    assert.ok(allLogs.includes('1.'), `Expected rule #1, got: ${JSON.stringify(logs)}`);
+    assert.ok(allLogs.includes('2.'), `Expected rule #2, got: ${JSON.stringify(logs)}`);
+    assert.ok(!allLogs.includes('3.'), `Expected no rule #3 (whitespace filtered), got: ${JSON.stringify(logs)}`);
+  });
+});
+
+// Suite 3: Admin commands (kick / ban / givecurrency) -----------------------
+
+describe('utils: admin commands', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let kickRoleId: string | undefined;
+  let banRoleId: string | undefined;
+  let currencyRoleId: string | undefined;
+  // player names for player-type argument resolution (Takaro resolves by name, not UUID)
+  let playerNames: string[] = [];
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    // Enable economy for currency tests
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        discordLink: '',
+        rules: [],
+        serverInfoMessage: '',
+        broadcastCurrencyGrants: true,
+        currencyGrantBroadcastMessage: '{player} received {amount} currency from {admin}.',
+        broadcastKicks: true,
+        kickBroadcastMessage: '{player} was kicked by {admin}. Reason: {reason}',
+        broadcastBans: true,
+        banBroadcastMessage: '{player} was banned by {admin} for {duration}. Reason: {reason}',
+        banPermBroadcastMessage: '{player} was permanently banned by {admin}. Reason: {reason}',
+      },
+    });
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    // Fetch player names — Takaro resolves player-type arguments by name, not UUID
+    playerNames = await Promise.all(
+      ctx.players.map((p) => fetchPlayerName(client, p.playerId)),
+    );
+
+    // player[0] = kick admin, player[1] = ban admin, player[2] = currency admin & target
+    kickRoleId = await assignPermissions(client, ctx.players[0].playerId, ctx.gameServer.id, ['UTILS_KICK']);
+    banRoleId = await assignPermissions(client, ctx.players[1].playerId, ctx.gameServer.id, ['UTILS_BAN']);
+    currencyRoleId = await assignPermissions(client, ctx.players[0].playerId, ctx.gameServer.id, ['UTILS_GIVE_CURRENCY']);
+
+    // Give player[0] some currency for self-givecurrency test
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 500 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, kickRoleId);
+    await cleanupRole(client, banRoleId);
+    await cleanupRole(client, currencyRoleId);
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  // --- /kick tests ---
+
+  it('/kick denied without UTILS_KICK permission', async () => {
+    // player[2] has no kick permission
+    const player = ctx.players[2]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[1]}`,
+      player.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure without permission, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/kick self-targeting is denied', async () => {
+    // player[0] has UTILS_KICK, tries to kick themselves
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[0]}`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for self-kick, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('cannot use this command on yourself')),
+      `Expected self-kick denial, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/kick works with UTILS_KICK permission and logs the kick', async () => {
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[2]} Griefing`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected kick to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('utils:kick')),
+      `Expected kick log, got: ${JSON.stringify(logs)}`,
+    );
+    assert.ok(
+      logs.some((msg) => msg.includes(`Kicked ${playerNames[2]}. Reason: Griefing`)),
+      `Expected admin PM confirmation in logs, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/kick with broadcast enabled logs broadcast message', async () => {
+    // broadcastKicks is true in this suite — player[2] may be offline after previous kick
+    // Use player[1] as target (ban admin can be kicked by kick admin)
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[1]} Testing broadcast`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected kick to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('[broadcast]')),
+      `Expected broadcast log when broadcastKicks=true, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/kick with no reason uses default reason', async () => {
+    // Ensure player[2] is online before this test (may have been kicked earlier).
+    // Use connectAll since the mock server doesn't support individual connect <playerN>.
+    await ctx.server.executeConsoleCommand('connectAll');
+
+    // Poll until player[2] shows as online in Takaro
+    const p2Id = ctx.players[2]!.playerId;
+    const deadline = Date.now() + 15000;
+    let p2IsOnline = false;
+    while (Date.now() < deadline) {
+      const result = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+        limit: 10,
+      });
+      if (result.data.data.some((p) => p.playerId === p2Id)) {
+        p2IsOnline = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    assert.ok(p2IsOnline, `Expected player[2] to be online within 15000ms before kick-default-reason test`);
+
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[2]}`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected kick to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('Kicked by an admin.')),
+      `Expected default reason "Kicked by an admin.", got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/kick offline target returns not-online message', async () => {
+    // Disconnect ALL players so player[2] is definitely offline.
+    // The mock server does not support individual disconnect by index —
+    // only disconnectAll is reliable. connectAll is used afterward to restore state.
+    const admin = ctx.players[0]!;
+    const p2Id = ctx.players[2]!.playerId;
+    await ctx.server.executeConsoleCommand('disconnectAll');
+
+    // Poll until player[2] shows as offline in Takaro
+    const offlineDeadline = Date.now() + 15000;
+    let p2IsOffline = false;
+    while (Date.now() < offlineDeadline) {
+      const result = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+        limit: 10,
+      });
+      if (!result.data.data.some((p) => p.playerId === p2Id)) {
+        p2IsOffline = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    assert.ok(p2IsOffline, `Expected player[2] to be offline within 15000ms for offline-kick test`);
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `kick ${playerNames[2]}`,
+      admin.playerId,
+    );
+
+    // Assert command behavior first — before reconnect cleanup — so a reconnect timeout
+    // fails separately from a command-behavior bug.
+    assert.equal(success, false, `Expected failure for offline target, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('not currently online')),
+      `Expected "not currently online" message for offline target, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Cleanup: reconnect players so downstream tests are not affected.
+    await ctx.server.executeConsoleCommand('connectAll');
+    const onlineDeadline = Date.now() + 30000;
+    let p2IsOnlineAgain = false;
+    while (Date.now() < onlineDeadline) {
+      const result = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+        limit: 10,
+      });
+      if (result.data.data.some((p) => p.playerId === p2Id)) {
+        p2IsOnlineAgain = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    assert.ok(p2IsOnlineAgain, `Expected player[2] to reconnect within 30000ms (cleanup)`);
+  });
+
+  // --- /ban tests ---
+
+  it('/ban denied without UTILS_BAN permission', async () => {
+    // player[2] has no ban permission
+    const player = ctx.players[2]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} 1h`,
+      player.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure without permission, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/ban self-targeting is denied', async () => {
+    const admin = ctx.players[1]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[1]} 1h`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for self-ban, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('cannot use this command on yourself')),
+      `Expected self-ban denial, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/ban rejects invalid duration "invalid-duration"', async () => {
+    const admin = ctx.players[1]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} invalid-duration`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for invalid duration, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('Invalid duration')),
+      `Expected invalid duration message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/ban rejects invalid duration "0m" (zero not allowed)', async () => {
+    const admin = ctx.players[1]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} 0m`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for 0m duration, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('Invalid duration')),
+      `Expected invalid duration message for 0m, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/ban works with temporary duration (1h) and payload has expiresAt', async () => {
+    const admin = ctx.players[1]!;
+    const target = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} 1h Temporary ban test`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected temp ban to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('utils:ban')),
+      `Expected ban log, got: ${JSON.stringify(logs)}`,
+    );
+
+    // VI-13: Parse payload log and assert expiresAt IS PRESENT for temp ban
+    const payloadLog = logs.find((msg) => msg.startsWith('utils:ban payload='));
+    assert.ok(payloadLog, `Expected payload log line, got: ${JSON.stringify(logs)}`);
+    const payloadStr = payloadLog!.replace('utils:ban payload=', '');
+    const payload = JSON.parse(payloadStr);
+    assert.ok('expiresAt' in payload, `Expected expiresAt in temp ban payload, got: ${JSON.stringify(payload)}`);
+    assert.ok(payload.expiresAt !== null && payload.expiresAt !== undefined, `expiresAt should not be null/undefined`);
+
+    assert.ok(
+      logs.some((msg) => msg.includes(`Banned ${playerNames[0]} for 1 hour. Reason:`)),
+      `Expected admin PM for temp ban in logs, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Unban player[0] so they can be used in subsequent tests
+    await client.gameserver.gameServerControllerUnbanPlayer(ctx.gameServer.id, target.playerId);
+  });
+
+  it('/ban works with permanent duration (perm) and payload has no expiresAt', async () => {
+    const admin = ctx.players[1]!;
+    const target = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} perm Permanent ban test`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected perm ban to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('permanent') || msg.includes('perm')),
+      `Expected permanent ban in payload log, got: ${JSON.stringify(logs)}`,
+    );
+
+    // VI-13: Parse payload log and assert expiresAt is ABSENT for perm ban
+    const payloadLog = logs.find((msg) => msg.startsWith('utils:ban payload='));
+    assert.ok(payloadLog, `Expected payload log line, got: ${JSON.stringify(logs)}`);
+    const payloadStr = payloadLog!.replace('utils:ban payload=', '');
+    const payload = JSON.parse(payloadStr);
+    assert.ok(!('expiresAt' in payload), `Expected no expiresAt in perm ban payload, got: ${JSON.stringify(payload)}`);
+
+    assert.ok(
+      logs.some((msg) => msg.includes(`Banned ${playerNames[0]} permanently. Reason:`)),
+      `Expected admin PM for perm ban in logs, got: ${JSON.stringify(logs)}`,
+    );
+
+    // Unban player[0] for cleanup
+    await client.gameserver.gameServerControllerUnbanPlayer(ctx.gameServer.id, target.playerId);
+  });
+
+  it('/ban perm with broadcast uses perm-specific template (no "for permanently")', async () => {
+    // VI-1: broadcastBans is true in this suite — verify perm ban broadcast uses correct grammar
+    const admin = ctx.players[1]!;
+    const target = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} perm Grammar test`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected perm ban to succeed, logs: ${JSON.stringify(logs)}`);
+
+    // Should broadcast using banPermBroadcastMessage template (no "for permanently")
+    const broadcastLog = logs.find((msg) => msg.startsWith('[broadcast]'));
+    assert.ok(broadcastLog, `Expected broadcast log, got: ${JSON.stringify(logs)}`);
+    assert.ok(
+      !broadcastLog!.includes('for permanently'),
+      `Expected no "for permanently" grammar, got: ${broadcastLog}`,
+    );
+    assert.ok(
+      broadcastLog!.includes('permanently'),
+      `Expected "permanently" in broadcast, got: ${broadcastLog}`,
+    );
+
+    // Unban for cleanup
+    await client.gameserver.gameServerControllerUnbanPlayer(ctx.gameServer.id, target.playerId);
+  });
+
+  it('/ban temp with broadcast uses temp template with duration', async () => {
+    const admin = ctx.players[1]!;
+    const target = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `ban ${playerNames[0]} 7d Temp broadcast test`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected temp ban to succeed, logs: ${JSON.stringify(logs)}`);
+
+    const broadcastLog = logs.find((msg) => msg.startsWith('[broadcast]'));
+    assert.ok(broadcastLog, `Expected broadcast log, got: ${JSON.stringify(logs)}`);
+    assert.ok(
+      broadcastLog!.includes('7 days'),
+      `Expected "7 days" in broadcast, got: ${broadcastLog}`,
+    );
+
+    // Unban for cleanup
+    await client.gameserver.gameServerControllerUnbanPlayer(ctx.gameServer.id, target.playerId);
+  });
+
+  // --- /givecurrency tests ---
+
+  it('/givecurrency denied without UTILS_GIVE_CURRENCY permission', async () => {
+    // player[1] has no currency permission; target player[0] (online throughout)
+    const player = ctx.players[1]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[0]} 50`,
+      player.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure without permission, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('do not have permission')),
+      `Expected permission denied message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/givecurrency rejects zero amount', async () => {
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[1]} 0`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for amount=0, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('positive whole number')),
+      `Expected positive whole number message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/givecurrency rejects negative amount', async () => {
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[1]} -10`,
+      admin.playerId,
+    );
+
+    assert.equal(success, false, `Expected failure for negative amount, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('positive whole number')),
+      `Expected positive whole number message, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/givecurrency succeeds and logs the grant', async () => {
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[1]} 100`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected givecurrency to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('utils:givecurrency')),
+      `Expected givecurrency log, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/givecurrency self-targeting is allowed', async () => {
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[0]} 10`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected self-givecurrency to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('utils:givecurrency')),
+      `Expected givecurrency log for self, got: ${JSON.stringify(logs)}`,
+    );
+  });
+
+  it('/givecurrency with broadcast enabled logs broadcast message', async () => {
+    // broadcastCurrencyGrants is true in this suite's install config
+    const admin = ctx.players[0]!;
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix,
+      `givecurrency ${playerNames[1]} 25`,
+      admin.playerId,
+    );
+
+    assert.equal(success, true, `Expected givecurrency to succeed, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('[broadcast]')),
+      `Expected broadcast log when broadcastCurrencyGrants=true, got: ${JSON.stringify(logs)}`,
+    );
+  });
+});
+
+// Suite 4: /online with no players ------------------------------------------
+
+describe('utils: /online no-players fallback', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        discordLink: '',
+        rules: [],
+        serverInfoMessage: '',
+      },
+    });
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+  });
+
+  after(async () => {
+    // Reconnect players before cleanup (they were disconnected in test)
+    try {
+      await ctx.server.executeConsoleCommand('connectAll');
+    } catch (err) {
+      console.error('Cleanup: failed to reconnect players:', err);
+    }
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (err) {
+      console.error('Cleanup: failed to uninstall module:', err);
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  it('/online shows no-players message when all players are disconnected', async () => {
+    const triggeringPlayer = ctx.players[0]!;
+
+    // Disconnect all players — commandControllerTrigger is an API call and does not
+    // require the triggering player to be in-game, so this is safe.
+    await ctx.server.executeConsoleCommand('disconnectAll');
+
+    // Poll Takaro until it reflects 0 online players (give up after 30s)
+    const deadline = Date.now() + 30000;
+    let allOffline = false;
+    while (Date.now() < deadline) {
+      const result = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+        filters: { gameServerId: [ctx.gameServer.id], online: [true] },
+        limit: 10,
+      });
+      if ((result.data.meta?.total ?? result.data.data.length) === 0) {
+        allOffline = true;
+        break;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    assert.ok(allOffline, `Expected all players to be offline within 30000ms for /online no-players test`);
+
+    const { success, logs } = await triggerCommand(
+      client, ctx, prefix, 'online', triggeringPlayer.playerId,
+    );
+
+    assert.equal(success, true, `Expected success, logs: ${JSON.stringify(logs)}`);
+    assert.ok(
+      logs.some((msg) => msg.includes('No players are currently online')),
+      `Expected no-players message when all players disconnected, got: ${JSON.stringify(logs)}`,
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new `utils` module that provides a small, reliable baseline of cross-game utility commands for Takaro. Four public commands (`/serverinfo`, `/online`, `/discord`, `/rules`) give players self-serve access to common server information without needing an admin. Three permission-gated admin commands (`/kick`, `/ban`, `/givecurrency`) cover baseline moderation and simple economy administration. The module is implemented on Takaro's generic API surface so it works consistently across game integrations.

Resolves #22.

## Architecture

```
modules/utils/
├── module.json                 — command defs, config schema, 3 permissions
├── src/commands/
│   ├── serverinfo/ online/ discord/ rules/     (public, no permission)
│   └── kick/ ban/ givecurrency/                (permission-gated)
└── src/functions/
    ├── utils-pure.js           ← single source of truth for pure helpers
    │   (isBlank, trimOrEmpty, normalizeReason, compactRules,
    │    formatOnlinePlayersLine, getCommandTargetPlayer,
    │    renderTemplate, parseBanDurationToken)
    └── utils-helpers.js        ← Takaro-dependent helpers only
        (fetchOnlinePlayers, getGameServerName,
         getPlayerName, safeBroadcast)

Commands split-import: pure helpers from ./utils-pure.js,
Takaro-dependent helpers from ./utils-helpers.js.
Both files are registered under module.json `functions` so
they ship to the Takaro runtime.
```

The helper split is unusual — the Takaro sandbox rejects function-to-function ES imports (silent empty-logs crash), which ruled out the simpler re-export pattern. Having commands import directly from `utils-pure.js` achieves the single-source-of-truth goal without the cross-helper import.

## What Changed

- **module.json**: 7 commands (with typed args — `player`, `duration`, `amount`, `reason`), 3 permissions (`UTILS_KICK`, `UTILS_BAN`, `UTILS_GIVE_CURRENCY`), config schema (discord link, rules array, info message, per-admin-command broadcast toggles + templates), and both `utils-helpers` and `utils-pure` registered under `functions`.
- **Public commands** (`serverinfo`, `online`, `discord`, `rules`): bare `pog.pm(...)` output — no try/catch around the sole user-visible result, letting delivery failures surface as normal exceptions per the project's anti-defensive programming philosophy.
- **Admin commands** (`kick`, `ban`, `givecurrency`): permission check → resolve target → self-target policy → normalize reason/duration → API call → admin confirmation PM (try/caught as non-fatal per plan §370) → optional broadcast via `safeBroadcast` helper. Permanent bans use a separate `banPermBroadcastMessage` template so the grammar reads naturally ("permanently banned by X" vs the "for permanently" error that was present early in development).
- **Pure helpers** (`utils-pure.js`): duration parser with `perm`/`permanent`/`Nm`/`Nh`/`Nd`/`Nw` grammar and singular/plural rendering; alphabetical-sort online-list formatter with 10-name truncation; template renderer with placeholder substitution; rule-list whitespace filter; player-target resolution and reason normalization.
- **Takaro helpers** (`utils-helpers.js`): paginated online-player fetch, game-server name lookup, player-name lookup, and a best-effort broadcast wrapper.
- **Tests**: 75 tests across 13 suites. Unit tests import pure helpers directly from `utils-pure.js` — the exact same code the runtime loads. Integration tests go through the real Takaro API via the mock-server harness (no Takaro mocking, per AGENTS.md).

## Reviewer Guide

- **Start here**: `modules/utils/module.json` (the canonical spec) and `modules/utils/src/functions/utils-pure.js` (the pure logic that drives each command). These two files together tell the whole story.
- **Pay attention to**: the helper split (novel-but-forced pattern — see Architecture). Also `ban/index.js:69-83` where the perm-vs-temp broadcast branching lives, since the default template grammar was a player-visible bug earlier. And `test/utils.test.ts:808-900` where the `/kick offline target` test uses an explicit `disconnectAll` + poll + post-loop-assertion pattern for determinism.
- **Design decision**: `utils-pure.js` + `utils-helpers.js` as two separately-registered Takaro functions is novel in this repo. The daily-rewards module took a different tack (both function files contain their own copies of pure functions — drift-prone). The pattern here eliminates drift because commands import directly from one canonical file. Simpler re-export (`utils-helpers.js` re-exports from `utils-pure.js`) fails silently in the Takaro sandbox.

## Testing Plan

### Happy Path
- [ ] Push & install on a mock game server with non-trivial config: `discordLink`, `rules: ["No griefing", "Be respectful", "No cheating"]`, `serverInfoMessage`, all three broadcast flags `true`.
- [ ] As any online player: run `/serverinfo` — verify server name + player count + info line.
- [ ] Run `/online` — verify alphabetical order of names.
- [ ] Run `/discord` — verify link reported.
- [ ] Run `/rules` — verify output STARTS with `"Server rules:"` header followed by numbered list.
- [ ] Grant `UTILS_KICK`/`UTILS_BAN`/`UTILS_GIVE_CURRENCY` to an admin bot.
- [ ] `/kick Bot_target griefing` — admin gets "Kicked Bot_target. Reason: griefing." + broadcast fires.
- [ ] `/ban Bot_target 10m spam` — admin gets "Banned Bot_target for 10 minutes. Reason: spam." + broadcast.
- [ ] `/ban Bot_target perm` (broadcastBans=true) — broadcast reads **"Bot_target was permanently banned by <admin>. Reason: Banned by an admin."** NOT "...for permanently..."
- [ ] `/givecurrency Bot_target 100` — admin gets "Gave 100 currency to Bot_target." + broadcast fires. No DM to target.

### Edge Cases
- [ ] Empty `discordLink` → `/discord` shows "This server has not configured a Discord link."
- [ ] Empty `rules` → `/rules` shows "This server has not configured any rules yet."
- [ ] Rules mixing valid + whitespace-only entries (`["No griefing", "   ", "\t"]`) → whitespace entries filtered out, only real rules shown with header.
- [ ] `/ban Bot_target 3x` → "Invalid duration. Use perm/permanent or a value like 10m, 12h, 7d, or 2w."
- [ ] `/ban Bot_target 0m` → same invalid-duration message (positive integer enforced).
- [ ] `/givecurrency Bot_target 0` → "Usage: givecurrency <player> <amount> — Amount must be a positive whole number." (also `-5`, `1.5`).
- [ ] `/kick self` / `/ban self` → "You cannot use this command on yourself." (deny).
- [ ] `/givecurrency self 50` → succeeds (self-top-up is allowed per plan).
- [ ] `/kick` target currently offline → "That player is not currently online."
- [ ] `/kick Bot_target` (no reason) → default "Kicked by an admin." applied.
- [ ] `/ban Bot_target 1h` (no reason) → default "Banned by an admin." applied.
- [ ] Any admin command issued by a player without the matching permission → "You do not have permission to use this command."

### Regression Checks
- [ ] Other modules (afk-kick, community-fund, daily-rewards, hello-world, kill-tracker, lottery, vote-restart) still install and run on the same game server without errors.
- [ ] `npm test` (or `npx tsx --test modules/utils/test/utils.test.ts` for just utils) still reports 75/75 pass.
- [ ] Module push/pull round-trip still works: `bash scripts/module-push.sh modules/utils` succeeds, then `bash scripts/module-pull.sh test-utils` produces a recognizable copy under `modules/utils-imported/`.

## Implementation Journey

Completed in 5 turns (of 10 budget), severity threshold 3.

| Turn | Phase | Summary | Outcome |
|------|-------|---------|---------|
| 1 | Verify | Initial implementation — 7 commands, helpers, tests | 25 issues → FEEDBACK (exerciser FAIL: "for permanently" broadcast grammar) |
| 2 | Verify | Fixed perm-ban grammar, removed /givecurrency over-engineering, added coverage tests | 11 issues → FEEDBACK (coach gave two bad guidance items needing reversal) |
| 3 | Verify | Reversed bad guidance; first helper-split attempt (utils-pure.js as test copy) | 11 issues → FEEDBACK (split introduced DRY violation) |
| 4 | Verify | Proper helper split: utils-pure.js single source, both files registered, commands import pure directly | 5 issues → FEEDBACK (all sev 3-4 polish) |
| 5 | Verify | Comment accuracy, isBlank edge cases, test reorder, PM content assertions | 0 issues → APPROVED + exerciser PASSED |

The loop had two distinct friction sources. First: the initial implementation over-engineered `/givecurrency` (economy pre-check, online requirement not in plan) and mis-rendered the permanent-ban broadcast ("was banned by X for permanently"). Second: two coach-feedback errors in turn 1 were caught by review in turn 2 and required explicit reversal in turn 3 — the `/rules` "Server rules:" header was wrongly removed, and the `pog.pm` try/catch was applied too broadly to public commands where the PM is the sole user-visible output. The pure-vs-Takaro-dependent helper split took three iterations (TS replica → duplicate .js file → single source of truth) because the Takaro sandbox's function-to-function import restriction forced a non-obvious architecture.

## Friction Log

- **Perm-ban broadcast grammar** (`modules/utils/src/commands/ban/index.js:69-83` + `module.json` default `banPermBroadcastMessage`): Initial default template `"{player} was banned by {admin} for {duration}. Reason: {reason}"` combined with `duration: 'permanently'` for perm bans produced "banned by X for permanently" — ungrammatical and player-visible. Fixed via a separate `banPermBroadcastMessage` config field that omits the "for". If you edit the broadcast templates, keep the perm and temp phrasings separate and verify in-game with `broadcastBans: true`.
- **`/givecurrency` over-engineering** (`modules/utils/src/commands/givecurrency/index.js`): Removed an `isEconomyEnabled` pre-check, a `getSameServerOnlineRequirementError` online-requirement check, and an undocumented recipient DM — none in the plan. If future requirements call for any of these, add them back with explicit plan updates.
- **Helper drift** (`modules/utils/src/functions/utils-pure.js` + `utils-helpers.js` + `module.json` `functions`): The final layout is unusual — both files registered as Takaro functions, commands split-import between them. Simpler re-export fails in the Takaro sandbox (empty-logs crash). If you're tempted to consolidate, verify the sandbox still accepts function-to-function imports first.
- **Coach-feedback reversals** (turn 1 → turn 3): Early loop feedback incorrectly removed the `/rules` "Server rules:" header (plan line 111 shows it) and over-broadly wrapped `pog.pm` in try/catch. Both reversed. Mentioning this so if the header or try/catch pattern looks off, the history explains why.
- **Test-order dependencies** (`modules/utils/test/utils.test.ts`): Early `/kick offline-target` and `/kick default-reason` tests silently passed when they relied on prior test order. The current pattern uses explicit `disconnectAll` + poll + post-loop `assert.ok(condition, ...)` for determinism. If you add similar tests, follow this pattern rather than relying on prior test effects.

## Below-Threshold Issues

These passed the sev-3 threshold but are worth mentioning in case you want to polish them:

- (sev 2) `trimOrEmptyInternal` in `utils-helpers.js` duplicates `trimOrEmpty` in `utils-pure.js` — forced by the sandbox constraint. One-liner so drift risk is minimal.
- (sev 2) `renderTemplate` unit tests don't cover `null`/`undefined` placeholder values.
- (sev 2) `/givecurrency` admin PM uses active voice "Gave..." while `/kick`/`/ban` use passive "Kicked.../Banned..." — cosmetic.
- (sev 2) `banPermBroadcastMessage` has an inline fallback default in `ban/index.js` that duplicates the module.json default. Admin who blanks the field to suppress broadcasts would see the fallback instead of silence.
- (sev 2) One test name (`/rules filters whitespace-only entries` in the public-commands suite) is slightly misleading — the actual whitespace-filter verification is in a separate dedicated suite.