### PR TITLE
Fix dynamic racing module imports and betting

### DIFF
--- a/.claude/plans/issue-43-dynamic-racing.md
+++ b/.claude/plans/issue-43-dynamic-racing.md
@@ -1,0 +1,64 @@
+# Issue #43: Dynamic Racing Module Repair
+
+## Summary
+Fix GitHub issue #43 by importing the attached `ZombieRacing` Takaro export into `modules/zombie-racing`, repairing runtime breakages, and turning it into a configurable racing module where admins can theme entrants as zombies, horses, or another racer type. Execute with `player-coach` settings: 15 turns, severity threshold 3, PR + CI enabled.
+
+## Key Changes
+- Import the issue attachment into local module structure using the existing JSON-to-module workflow, targeting `modules/zombie-racing`.
+- Standardize module behavior around generic "racers" while preserving sensible defaults for zombies:
+  - Config fields: `racerTypeLabel`, `racerTypePluralLabel`, `raceName`, `entrants`, `minBet`, `maxBet`.
+  - Entrants remain editable as one string per line/array item using `Name; Odds`.
+  - Runtime should tolerate legacy `Zombies` and `Horses` config by falling back to them if `entrants` is absent.
+- Repair broken public command/API surfaces:
+  - Use command triggers consistently: `racers`, `racebet`, `myracebets`, `racestats`, `raceleaderboard`, `nextrace`, `lastrace`, `startrace`.
+  - Keep command arguments aligned with code: `racebet <racer> <amount>`.
+  - Use permissions that match code and metadata: `RACING_BET` and `RACING_ADMIN`.
+  - Update descriptions/help text so they no longer mention horse-only behavior unless configured labels do.
+- Consolidate duplicated race-state logic into helper functions in the module's `utils` function:
+  - parse entrants, find entrant, get/update race data, simulate weighted race, format labels/messages, update stats, jackpot handling.
+  - Use one race variable key for this module and avoid cross-module/global state collisions.
+- Remove or disable the placeholder `test` log hook unless it is needed for a real behavior; do not ship placeholder regex/function metadata.
+- Fix known logic bugs from inspection:
+  - `zombieBet` currently reads `args.zombie` but metadata defines `horse`; make this `args.racer`.
+  - Config currently defines `Horses` while code reads `Zombies`; replace with `entrants` plus legacy fallback.
+  - `nextRace` reads `bet.horse`; use the canonical bet racer field.
+  - `lastRace` calculates player losing bets and total bets from winners only; store/read full race bet count and player bets in race results.
+  - Remove `setTimeout` delays from command execution; use immediate sequential messages suitable for Takaro function runtime.
+
+## Tests And Verification
+- Add real Takaro API integration tests under `modules/zombie-racing/test/`.
+- Test module import/install with custom config:
+  - zombie-themed defaults work.
+  - horse-themed config changes visible command output and entrant names.
+  - legacy `Zombies` or `Horses` config still parses if `entrants` is missing.
+- Test command/cron flow through real API:
+  - `racers` lists configured entrants and bet limits.
+  - `racebet <racer> <amount>` validates permissions, entrant names, min/max amount, and currency balance.
+  - replacing an existing bet refunds the previous wager.
+  - `myracebets`, `nextrace`, `lastrace`, `racestats`, and `raceleaderboard` return useful output without runtime errors.
+  - `runRace` pays winners, records last race, clears current bets, advances race number, and updates player stats.
+  - no-bet races complete successfully without payouts.
+- Run required verification:
+  - `npm run build`
+  - targeted module tests if available, otherwise `npm test`
+  - `scripts/module-push.sh modules/zombie-racing` after build
+  - mandatory in-game verification with Paper + bot service: start `paper bot redis`, create at least one bot, trigger commands in Minecraft, verify command/cron execution events and messages.
+
+## Player-Coach Execution
+- Start player-coach with:
+  - max turns: `15`
+  - severity threshold: `3`
+  - PR + CI: enabled
+- Every turn must run `/verify --mode=report-only --scope=branch`.
+- Approval is blocked unless the exerciser runs and passes.
+- After local verification passes, create/update the PR and monitor CI; CI failures consume remaining turns.
+
+## Assumptions
+- The attached issue JSON is the source of truth for the initial module.
+- The final module remains named `zombie-racing` locally for issue traceability, while its runtime labels are configurable.
+- We will not add mocked unit tests or `globalThis.__mocks`; tests must use the real Takaro API pattern already used in this repo.
+
+## Turn 4 Notes
+- Addressed verification feedback by making `racebet` persist race state before the final net currency adjustment and restore the prior race state if that adjustment fails.
+- Kept replacement-bet refund coverage by changing the targeted test to replace a 250 wager with a 100 wager and assert the refund path.
+- Confirmed `module.json` has the corrected `announceRace` and `runRace` cron schedules in the working tree before staging.

--- a/modules/zombie-racing/module.json
+++ b/modules/zombie-racing/module.json
@@ -1,0 +1,169 @@
+{
+  "name": "test-zombie-racing",
+  "author": "Limon",
+  "description": "A configurable virtual racing system where players can bet on named racers.",
+  "version": "latest",
+  "supportedGames": [
+    "all"
+  ],
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [],
+    "additionalProperties": true,
+    "properties": {
+      "minBet": {
+        "title": "minBet",
+        "description": "Minimum amount required to place a bet",
+        "default": 50,
+        "type": "number",
+        "minimum": 1
+      },
+      "maxBet": {
+        "title": "maxBet",
+        "description": "Maximum amount allowed for a bet",
+        "default": 1000,
+        "type": "number",
+        "minimum": 1
+      },
+      "racerTypeLabel": {
+        "title": "Racer type label",
+        "description": "Singular label for racers in command output.",
+        "default": "zombie",
+        "type": "string"
+      },
+      "racerTypePluralLabel": {
+        "title": "Racer type plural label",
+        "description": "Plural label for racers in command output.",
+        "default": "zombies",
+        "type": "string"
+      },
+      "raceName": {
+        "title": "Race name",
+        "description": "Display name for races.",
+        "default": "Zombie Race",
+        "type": "string"
+      },
+      "entrants": {
+        "title": "Entrants",
+        "description": "List of racers. Format: Name; Odds (whole number) - one racer per line.",
+        "default": [
+          "Biker; 2",
+          "Arlene; 3",
+          "Darlene; 3",
+          "Chuck; 4",
+          "Moe; 5",
+          "Nurse; 6"
+        ],
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "permissions": [
+    {
+      "canHaveCount": false,
+      "description": "Allows the player to bet on races",
+      "permission": "RACING_BET",
+      "friendlyName": "Place Racing Bets"
+    },
+    {
+      "canHaveCount": false,
+      "description": "Allows the player to manage races",
+      "permission": "RACING_ADMIN",
+      "friendlyName": "Racing Admin"
+    }
+  ],
+  "commands": {
+    "raceleaderboard": {
+      "trigger": "raceleaderboard",
+      "description": "Show the top racing bettors and their statistics",
+      "helpText": "Usage: /raceleaderboard",
+      "function": "src/commands/raceleaderboard/index.js",
+      "arguments": []
+    },
+    "racers": {
+      "trigger": "racers",
+      "description": "List configured racers and race information",
+      "helpText": "Usage: /racers",
+      "function": "src/commands/racers/index.js",
+      "arguments": []
+    },
+    "racestats": {
+      "trigger": "racestats",
+      "description": "View your detailed racing statistics",
+      "helpText": "Usage: /racestats",
+      "function": "src/commands/racestats/index.js",
+      "arguments": []
+    },
+    "startrace": {
+      "trigger": "startrace",
+      "description": "Manually start a race (admin only)",
+      "helpText": "Usage: /startrace",
+      "function": "src/commands/startrace/index.js",
+      "arguments": []
+    },
+    "lastrace": {
+      "trigger": "lastrace",
+      "description": "Show the last race results",
+      "helpText": "Usage: /lastrace",
+      "function": "src/commands/lastrace/index.js",
+      "arguments": []
+    },
+    "nextrace": {
+      "trigger": "nextrace",
+      "description": "Show upcoming race information",
+      "helpText": "Usage: /nextrace",
+      "function": "src/commands/nextrace/index.js",
+      "arguments": []
+    },
+    "myracebets": {
+      "trigger": "myracebets",
+      "description": "Show your current race bets",
+      "helpText": "Usage: /myracebets",
+      "function": "src/commands/myracebets/index.js",
+      "arguments": []
+    },
+    "racebet": {
+      "trigger": "racebet",
+      "description": "Place a bet on a racer for the next race",
+      "helpText": "Usage: /racebet <racer> <amount>",
+      "function": "src/commands/racebet/index.js",
+      "arguments": [
+        {
+          "name": "racer",
+          "type": "string",
+          "defaultValue": "",
+          "helpText": "Name of the racer you want to bet on",
+          "position": 0
+        },
+        {
+          "name": "amount",
+          "type": "number",
+          "defaultValue": "0",
+          "helpText": "Amount of currency to bet",
+          "position": 1
+        }
+      ]
+    }
+  },
+  "cronJobs": {
+    "announceRace": {
+      "temporalValue": "45 1-23/2 * * *",
+      "description": "Announce each upcoming two-hour race 15 minutes before it starts",
+      "function": "src/cronjobs/announceRace/index.js"
+    },
+    "runRace": {
+      "temporalValue": "0 */2 * * *",
+      "description": "Run the scheduled race every two hours",
+      "function": "src/cronjobs/runRace/index.js"
+    }
+  },
+  "functions": {
+    "utils": {
+      "function": "src/functions/utils.js"
+    }
+  }
+}

--- a/modules/zombie-racing/src/commands/lastrace/index.js
+++ b/modules/zombie-racing/src/commands/lastrace/index.js
@@ -1,0 +1,31 @@
+import { data, TakaroUserError } from '@takaro/helpers';
+import { getRaceData, getRaceLabels } from './utils.js';
+
+async function main() {
+  const { pog, player, gameServerId, module: mod } = data;
+  const labels = getRaceLabels(mod.userConfig);
+  const raceData = await getRaceData(gameServerId, mod.moduleId);
+
+  if (!raceData.lastRaceResults) {
+    throw new TakaroUserError(`No completed ${labels.raceName} results are available yet.`);
+  }
+
+  const result = raceData.lastRaceResults;
+  const playerId = pog.playerId || player.id;
+  const playerBets = (result.bets || []).filter((bet) => bet.playerId === playerId);
+  const playerWin = (result.winners || []).find((bet) => bet.playerId === playerId);
+
+  await pog.pm(`${labels.raceName} #${result.raceNumber} winner: ${result.winner}.`);
+  await pog.pm(`Final standings: ${(result.results || []).slice(0, 3).map((entrant, index) => `${index + 1}. ${entrant.name}`).join(', ')}.`);
+  await pog.pm(`Race stats: ${result.totalBets || 0} bets, ${result.totalWagered || 0} wagered, ${result.totalPayout || 0} paid out.`);
+  if (playerWin) {
+    await pog.pm(`You won ${playerWin.payout} with your ${playerWin.amount} bet on ${playerWin.racer}.`);
+  } else if (playerBets.length > 0) {
+    await pog.pm(`Your ${playerBets.length} bet${playerBets.length === 1 ? '' : 's'} did not win this race.`);
+  } else {
+    await pog.pm('You did not place a bet in this race.');
+  }
+  console.log(`racing:lastrace race=${result.raceNumber} totalBets=${result.totalBets || 0}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/myracebets/index.js
+++ b/modules/zombie-racing/src/commands/myracebets/index.js
@@ -1,0 +1,34 @@
+import { data, TakaroUserError } from '@takaro/helpers';
+import { getRaceData, getRaceLabels } from './utils.js';
+
+async function main() {
+  try {
+    const { pog, player, gameServerId, module: mod } = data;
+    const labels = getRaceLabels(mod.userConfig);
+    const raceData = await getRaceData(gameServerId, mod.moduleId);
+    const playerId = pog.playerId || player.id;
+    const playerBets = raceData.bets.filter((bet) => bet.playerId === playerId);
+
+    if (playerBets.length === 0) {
+      await pog.pm(`You have not placed any bets for ${labels.raceName} #${raceData.raceNumber}.`);
+      await pog.pm(`Use /racebet <${labels.racerTypeLabel}> <amount> to place a bet.`);
+      console.log(`racing:myracebets player=${player.name} bets=0`);
+      return;
+    }
+
+    let totalPotential = 0;
+    await pog.pm(`Your bets for ${labels.raceName} #${raceData.raceNumber}:`);
+    for (const bet of playerBets) {
+      const potential = Math.floor(bet.amount * bet.odds);
+      totalPotential += potential;
+      await pog.pm(`${bet.racer}: ${bet.amount} bet, potential win ${potential}.`);
+    }
+    await pog.pm(`Total potential winnings: ${totalPotential}.`);
+    console.log(`racing:myracebets player=${player.name} bets=${playerBets.length} racers=${playerBets.map((bet) => bet.racer).join('|')} potential=${totalPotential}`);
+  } catch (err) {
+    console.error(`racing:myracebets failed: ${err}`);
+    throw new TakaroUserError('Unable to load your race bets. Please try again.');
+  }
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/nextrace/index.js
+++ b/modules/zombie-racing/src/commands/nextrace/index.js
@@ -1,0 +1,28 @@
+import { data, TakaroUserError } from '@takaro/helpers';
+import { getRaceData, getRaceLabels, getTimeUntilRace } from './utils.js';
+
+async function main() {
+  try {
+    const { pog, player, gameServerId, module: mod } = data;
+    const labels = getRaceLabels(mod.userConfig);
+    const raceData = await getRaceData(gameServerId, mod.moduleId);
+    const playerId = pog.playerId || player.id;
+    const playerBets = raceData.bets.filter((bet) => bet.playerId === playerId);
+
+    await pog.pm(`${labels.raceName} #${raceData.raceNumber} begins in ${getTimeUntilRace(raceData.nextRaceTime)}.`);
+    await pog.pm(`${raceData.bets.length} total bet${raceData.bets.length === 1 ? '' : 's'} have been placed.`);
+    if (playerBets.length > 0) {
+      for (const bet of playerBets) {
+        await pog.pm(`Your bet: ${bet.racer} for ${bet.amount} (potential win ${Math.floor(bet.amount * bet.odds)}).`);
+      }
+    } else {
+      await pog.pm(`You have no bets yet. Use /racebet <${labels.racerTypeLabel}> <amount>.`);
+    }
+    console.log(`racing:nextrace race=${raceData.raceNumber} bets=${raceData.bets.length} playerBets=${playerBets.map((bet) => `${bet.racer}:${bet.amount}`).join('|')}`);
+  } catch (err) {
+    console.error(`racing:nextrace failed: ${err}`);
+    throw new TakaroUserError('Unable to load the next race. Please try again.');
+  }
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/racebet/index.js
+++ b/modules/zombie-racing/src/commands/racebet/index.js
@@ -1,0 +1,97 @@
+import { data, takaro, checkPermission, TakaroUserError } from '@takaro/helpers';
+import { acquireRaceLock, findEntrant, getRaceData, getRaceLabels, parseEntrants, releaseRaceLock, updateRaceData } from './utils.js';
+
+async function main() {
+  const { pog, player, gameServerId, module: mod, arguments: args } = data;
+  if (!checkPermission(pog, 'RACING_BET')) {
+    throw new TakaroUserError('You do not have permission to place race bets.');
+  }
+
+  const labels = getRaceLabels(mod.userConfig);
+  const racerName = String(args.racer || '').trim();
+  const amount = Number(args.amount);
+  const minBet = mod.userConfig?.minBet || 50;
+  const maxBet = mod.userConfig?.maxBet || 1000;
+
+  if (!racerName) {
+    throw new TakaroUserError(`Usage: racebet <${labels.racerTypeLabel}> <amount>.`);
+  }
+  if (!Number.isInteger(amount) || amount < minBet || amount > maxBet) {
+    throw new TakaroUserError(`Bet amount must be a whole number between ${minBet} and ${maxBet}.`);
+  }
+
+  const entrants = parseEntrants(mod.userConfig);
+  const entrant = findEntrant(entrants, racerName);
+  if (!entrant) {
+    throw new TakaroUserError(`${labels.racerTypeLabel} "${racerName}" was not found. Available ${labels.racerTypePluralLabel}: ${entrants.map((e) => e.name).join(', ')}.`);
+  }
+
+  const lockOwner = await acquireRaceLock(gameServerId, mod.moduleId, 'racebet');
+  try {
+    const raceData = await getRaceData(gameServerId, mod.moduleId);
+    if (raceData.completion?.raceNumber === raceData.raceNumber) {
+      throw new TakaroUserError('This race is being completed. Please wait for the next race before placing another bet.');
+    }
+    const playerId = pog.playerId || player.id;
+    const existingBetIndex = raceData.bets.findIndex((bet) => bet.playerId === playerId);
+    const existingBet = existingBetIndex >= 0 ? raceData.bets[existingBetIndex] : null;
+    const currentCurrency = pog.currency || 0;
+    const availableCurrency = currentCurrency + (existingBet?.amount || 0);
+
+    if (availableCurrency < amount) {
+      throw new TakaroUserError(`You don't have enough currency. You have ${currentCurrency}${existingBet ? ` plus ${existingBet.amount} from your existing bet` : ''} but tried to bet ${amount}.`);
+    }
+
+    const originalRaceData = {
+      ...raceData,
+      bets: raceData.bets.map((bet) => ({ ...bet })),
+    };
+    const newBet = {
+      playerId,
+      playerName: player.name,
+      racer: entrant.name,
+      amount,
+      odds: entrant.odds,
+      placedAt: Date.now(),
+    };
+    if (existingBetIndex >= 0) {
+      raceData.bets.splice(existingBetIndex, 1, newBet);
+    } else {
+      raceData.bets.push(newBet);
+    }
+    await updateRaceData(gameServerId, mod.moduleId, raceData);
+
+    const netCurrencyChange = amount - (existingBet?.amount || 0);
+    try {
+      if (netCurrencyChange > 0) {
+        await takaro.playerOnGameserver.playerOnGameServerControllerDeductCurrency(gameServerId, playerId, {
+          currency: netCurrencyChange,
+        });
+      } else if (netCurrencyChange < 0) {
+        await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, playerId, {
+          currency: Math.abs(netCurrencyChange),
+        });
+      }
+    } catch (err) {
+      await updateRaceData(gameServerId, mod.moduleId, originalRaceData);
+      console.error(`racing:racebet currency update failed after race state write for player=${player.name}. Error: ${err}`);
+      throw new TakaroUserError('Unable to place your race bet because the currency update failed. Your previous bet was restored.');
+    }
+
+    if (existingBet) {
+      await pog.pm(`Replaced your previous ${existingBet.amount} bet on ${existingBet.racer}.`);
+      if (netCurrencyChange < 0) {
+        await pog.pm(`Refunded ${Math.abs(netCurrencyChange)} from your previous bet.`);
+      }
+    }
+
+    const potentialWin = Math.floor(amount * entrant.odds);
+    await pog.pm(`Bet placed: ${amount} on ${entrant.name} (${entrant.odds}:1 odds). Potential winnings: ${potentialWin}.`);
+    await pog.pm(`Race #${raceData.raceNumber} now has ${raceData.bets.length} bet${raceData.bets.length === 1 ? '' : 's'}.`);
+    console.log(`racing:racebet player=${player.name} racer=${entrant.name} amount=${amount} odds=${entrant.odds} race=${raceData.raceNumber} bets=${raceData.bets.length}`);
+  } finally {
+    await releaseRaceLock(gameServerId, mod.moduleId, lockOwner);
+  }
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/raceleaderboard/index.js
+++ b/modules/zombie-racing/src/commands/raceleaderboard/index.js
@@ -1,0 +1,45 @@
+import { data, takaro, TakaroUserError } from '@takaro/helpers';
+import { RACING_STATS_KEY, getRaceLabels } from './utils.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+  const labels = getRaceLabels(mod.userConfig);
+  const statsSearch = await takaro.variable.variableControllerSearch({
+    filters: {
+      key: [RACING_STATS_KEY],
+      gameServerId: [gameServerId],
+      moduleId: [mod.moduleId],
+    },
+    limit: 100,
+  });
+
+  const allStats = [];
+  for (const statVar of statsSearch.data.data) {
+    try {
+      const stats = JSON.parse(statVar.value);
+      allStats.push({
+        playerName: stats.playerName || statVar.playerId,
+        totalBets: stats.totalBets || 0,
+        wins: stats.wins || 0,
+        net: (stats.totalWinnings || 0) - (stats.totalWagered || 0),
+        biggestWin: stats.biggestWin || 0,
+      });
+    } catch (err) {
+      console.error(`racing:raceleaderboard skipped bad stat ${statVar.id}: ${err}`);
+    }
+  }
+
+  if (allStats.length === 0) {
+    throw new TakaroUserError(`No ${labels.raceName} statistics are available yet.`);
+  }
+
+  allStats.sort((a, b) => b.net - a.net || b.wins - a.wins);
+  await pog.pm(`${labels.raceName} leaderboard:`);
+  for (const [index, stats] of allStats.slice(0, 10).entries()) {
+    const winRate = stats.totalBets > 0 ? Math.round((stats.wins / stats.totalBets) * 100) : 0;
+    await pog.pm(`${index + 1}. ${stats.playerName}: net ${stats.net}, ${stats.wins}/${stats.totalBets} wins (${winRate}%), biggest win ${stats.biggestWin}.`);
+  }
+  console.log(`racing:raceleaderboard rows=${allStats.length}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/racers/index.js
+++ b/modules/zombie-racing/src/commands/racers/index.js
@@ -1,0 +1,27 @@
+import { data, TakaroUserError } from '@takaro/helpers';
+import { getRaceData, getRaceLabels, getTimeUntilRace, parseEntrants } from './utils.js';
+
+async function main() {
+  try {
+    const { pog, gameServerId, module: mod } = data;
+    const labels = getRaceLabels(mod.userConfig);
+    const entrants = parseEntrants(mod.userConfig);
+    const raceData = await getRaceData(gameServerId, mod.moduleId);
+    const minBet = mod.userConfig?.minBet || 50;
+    const maxBet = mod.userConfig?.maxBet || 1000;
+
+    await pog.pm(`${labels.raceName}: Race #${raceData.raceNumber} starts in ${getTimeUntilRace(raceData.nextRaceTime)}.`);
+    await pog.pm(`Available ${labels.racerTypePluralLabel}:`);
+    for (const entrant of entrants) {
+      const betCount = raceData.bets.filter((bet) => bet.racer.toLowerCase() === entrant.name.toLowerCase()).length;
+      await pog.pm(`${entrant.name} - ${entrant.odds}:1 odds${betCount > 0 ? ` (${betCount} bets)` : ''}`);
+    }
+    await pog.pm(`Bet range: ${minBet}-${maxBet}. Use /racebet <${labels.racerTypeLabel}> <amount>.`);
+    console.log(`racing:racers raceName="${labels.raceName}" label=${labels.racerTypePluralLabel} entrants=${entrants.map((entrant) => `${entrant.name}:${entrant.odds}`).join('|')} minBet=${minBet} maxBet=${maxBet} bets=${raceData.bets.length}`);
+  } catch (err) {
+    console.error(`racing:racers failed: ${err}`);
+    throw new TakaroUserError('Unable to load race information. Please try again.');
+  }
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/racestats/index.js
+++ b/modules/zombie-racing/src/commands/racestats/index.js
@@ -1,0 +1,31 @@
+import { data, takaro, TakaroUserError } from '@takaro/helpers';
+import { RACING_STATS_KEY, getRaceLabels } from './utils.js';
+
+async function main() {
+  const { pog, player, gameServerId, module: mod } = data;
+  const playerId = pog.playerId || player.id;
+  const labels = getRaceLabels(mod.userConfig);
+  const statsSearch = await takaro.variable.variableControllerSearch({
+    filters: {
+      key: [RACING_STATS_KEY],
+      gameServerId: [gameServerId],
+      moduleId: [mod.moduleId],
+      playerId: [playerId],
+    },
+  });
+
+  if (statsSearch.data.data.length === 0) {
+    throw new TakaroUserError(`You do not have ${labels.raceName} stats yet. Place a bet and wait for a race to finish.`);
+  }
+
+  const stats = JSON.parse(statsSearch.data.data[0].value);
+  const winRate = stats.totalBets > 0 ? Math.round((stats.wins / stats.totalBets) * 100) : 0;
+  const net = (stats.totalWinnings || 0) - (stats.totalWagered || 0);
+  await pog.pm(`${labels.raceName} stats for ${player.name}:`);
+  await pog.pm(`Bets: ${stats.totalBets}, wins: ${stats.wins}, losses: ${stats.losses}, win rate: ${winRate}%.`);
+  await pog.pm(`Wagered: ${stats.totalWagered}, winnings: ${stats.totalWinnings}, net: ${net}, biggest win: ${stats.biggestWin}.`);
+  await pog.pm(`Favorite ${labels.racerTypeLabel}: ${stats.favoriteRacer || 'none'}.`);
+  console.log(`racing:racestats player=${player.name} bets=${stats.totalBets} wins=${stats.wins} losses=${stats.losses} favorite=${stats.favoriteRacer || 'none'}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/commands/startrace/index.js
+++ b/modules/zombie-racing/src/commands/startrace/index.js
@@ -1,0 +1,20 @@
+import { data, takaro, checkPermission, TakaroUserError } from '@takaro/helpers';
+import { completeRace, getRaceLabels } from './utils.js';
+
+async function main() {
+  const { pog, gameServerId, module: mod } = data;
+  if (!checkPermission(pog, 'RACING_ADMIN')) {
+    throw new TakaroUserError('You need racing admin permission to start races.');
+  }
+
+  const labels = getRaceLabels(mod.userConfig);
+  const { result } = await completeRace(gameServerId, mod.moduleId, mod.userConfig);
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `${labels.raceName} #${result.raceNumber} finished. Winner: ${result.winner}.`,
+    opts: {},
+  });
+  await pog.pm(`${labels.raceName} #${result.raceNumber} completed. ${result.totalBets} bets, ${result.totalPayout} paid out.`);
+  console.log(`racing:startrace race=${result.raceNumber} winner=${result.winner} bets=${result.totalBets}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/cronjobs/announceRace/index.js
+++ b/modules/zombie-racing/src/cronjobs/announceRace/index.js
@@ -1,0 +1,27 @@
+import { data, takaro } from '@takaro/helpers';
+import { getRaceData, getRaceLabels, getTimeUntilRace, parseEntrants } from './utils.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const labels = getRaceLabels(mod.userConfig);
+  const entrants = parseEntrants(mod.userConfig);
+  const raceData = await getRaceData(gameServerId, mod.moduleId);
+  const minBet = mod.userConfig?.minBet || 50;
+  const maxBet = mod.userConfig?.maxBet || 1000;
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `${labels.raceName} #${raceData.raceNumber} begins in ${getTimeUntilRace(raceData.nextRaceTime)}. ${raceData.bets.length} bets placed.`,
+    opts: {},
+  });
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `Available ${labels.racerTypePluralLabel}: ${entrants.map((entrant) => `${entrant.name} (${entrant.odds}:1)`).join(', ')}`,
+    opts: {},
+  });
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `Use /racebet <${labels.racerTypeLabel}> <amount>. Bet range: ${minBet}-${maxBet}.`,
+    opts: {},
+  });
+  console.log(`racing:announceRace race=${raceData.raceNumber} entrants=${entrants.length} bets=${raceData.bets.length}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/cronjobs/runRace/index.js
+++ b/modules/zombie-racing/src/cronjobs/runRace/index.js
@@ -1,0 +1,39 @@
+import { data, takaro } from '@takaro/helpers';
+import { completeRace, getRaceLabels } from './utils.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  const labels = getRaceLabels(mod.userConfig);
+  const { result } = await completeRace(gameServerId, mod.moduleId, mod.userConfig);
+  const topThree = (result.results || []).slice(0, 3).map((entrant, index) => `${index + 1}. ${entrant.name}`).join(', ');
+
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `${labels.raceName} #${result.raceNumber} is complete. Winner: ${result.winner}.`,
+    opts: {},
+  });
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message: `Final standings: ${topThree}.`,
+    opts: {},
+  });
+
+  if (result.totalBets === 0) {
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `No bets were placed. Next ${labels.raceName} is in 2 hours.`,
+      opts: {},
+    });
+  } else if (result.winners.length > 0) {
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `${result.winners.length} bettor${result.winners.length === 1 ? '' : 's'} won ${result.totalPayout} currency.`,
+      opts: {},
+    });
+  } else {
+    await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+      message: `Nobody bet on ${result.winner}. House wins this race.`,
+      opts: {},
+    });
+  }
+
+  console.log(`racing:runRace race=${result.raceNumber} winner=${result.winner} bets=${result.totalBets} payout=${result.totalPayout}`);
+}
+
+await main();

--- a/modules/zombie-racing/src/functions/utils.js
+++ b/modules/zombie-racing/src/functions/utils.js
@@ -1,0 +1,546 @@
+import { takaro, TakaroUserError } from '@takaro/helpers';
+
+export const RACE_STATE_KEY = 'zombie_racing_state_v1';
+export const RACING_STATS_KEY = 'zombie_racing_stats_v1';
+export const RACING_JACKPOT_KEY = 'zombie_racing_jackpot_v1';
+export const RACING_LOCK_KEY = 'zombie_racing_lock_v1';
+
+const LOCK_TIMEOUT_MS = 30000;
+const COMPLETION_ACTIVE_TIMEOUT_MS = 5 * 60 * 1000;
+
+export const DEFAULT_ENTRANTS = [
+  { name: 'Biker', odds: 2 },
+  { name: 'Arlene', odds: 3 },
+  { name: 'Darlene', odds: 3 },
+  { name: 'Chuck', odds: 4 },
+  { name: 'Moe', odds: 5 },
+  { name: 'Nurse', odds: 6 },
+];
+
+const DEFAULT_ENTRANT_LINES = DEFAULT_ENTRANTS.map((entrant) => `${entrant.name}; ${entrant.odds}`);
+
+function toPositiveInteger(value, fallback) {
+  const parsed = Number.parseInt(String(value), 10);
+  if (!Number.isFinite(parsed) || parsed < 1) return fallback;
+  return parsed;
+}
+
+export function getRaceLabels(config = {}) {
+  const racerTypeLabel = String(config.racerTypeLabel || 'zombie').trim() || 'zombie';
+  const racerTypePluralLabel = String(config.racerTypePluralLabel || `${racerTypeLabel}s`).trim() || `${racerTypeLabel}s`;
+  const raceName = String(config.raceName || 'Zombie Race').trim() || 'Zombie Race';
+  return { racerTypeLabel, racerTypePluralLabel, raceName };
+}
+
+export function parseEntrants(config = {}) {
+  const hasLegacyZombies = Array.isArray(config.Zombies);
+  const hasLegacyHorses = Array.isArray(config.Horses);
+  const configuredEntrants = Array.isArray(config.entrants) ? config.entrants : null;
+  const entrantsAreSchemaDefault = configuredEntrants
+    ? JSON.stringify(configuredEntrants) === JSON.stringify(DEFAULT_ENTRANT_LINES)
+    : false;
+  const rawEntrants = configuredEntrants && !(entrantsAreSchemaDefault && (hasLegacyZombies || hasLegacyHorses))
+    ? configuredEntrants
+    : hasLegacyZombies
+      ? config.Zombies
+      : hasLegacyHorses
+        ? config.Horses
+        : DEFAULT_ENTRANT_LINES;
+
+  const entrants = rawEntrants
+    .map((line) => {
+      const [rawName, rawOdds] = String(line).split(';');
+      const name = String(rawName || '').trim();
+      if (!name) return null;
+      return { name, odds: toPositiveInteger(rawOdds, 2) };
+    })
+    .filter(Boolean);
+
+  return entrants.length > 0 ? entrants : DEFAULT_ENTRANTS;
+}
+
+export function findEntrant(entrants, racerName) {
+  const normalized = String(racerName || '').trim().toLowerCase();
+  return entrants.find((entrant) => entrant.name.toLowerCase() === normalized) || null;
+}
+
+export function getTimeUntilRace(nextRaceTime) {
+  const timeRemaining = Number(nextRaceTime || 0) - Date.now();
+  if (timeRemaining <= 0) return 'any moment now';
+
+  const minutes = Math.floor(timeRemaining / 60000);
+  if (minutes < 60) return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (remainingMinutes === 0) return `${hours} hour${hours === 1 ? '' : 's'}`;
+  return `${hours} hour${hours === 1 ? '' : 's'} and ${remainingMinutes} minute${remainingMinutes === 1 ? '' : 's'}`;
+}
+
+export function initialRaceState() {
+  return {
+    nextRaceTime: Date.now() + (2 * 60 * 60 * 1000),
+    bets: [],
+    lastRaceResults: null,
+    raceNumber: 1,
+  };
+}
+
+export async function findVariable(gameServerId, moduleId, key, playerId) {
+  const filters = { key: [key], gameServerId: [gameServerId], moduleId: [moduleId] };
+  if (playerId) filters.playerId = [playerId];
+  const res = await takaro.variable.variableControllerSearch({ filters });
+  return res.data.data[0] || null;
+}
+
+export async function writeVariable(gameServerId, moduleId, key, value, playerId) {
+  const existing = await findVariable(gameServerId, moduleId, key, playerId);
+  const serialized = JSON.stringify(value);
+  if (existing) {
+    await takaro.variable.variableControllerUpdate(existing.id, { value: serialized });
+    return;
+  }
+
+  const payload = { key, value: serialized, gameServerId, moduleId };
+  if (playerId) payload.playerId = playerId;
+  await takaro.variable.variableControllerCreate(payload);
+}
+
+function parseVariableValue(variable) {
+  if (!variable) return null;
+  try {
+    return JSON.parse(variable.value);
+  } catch (_err) {
+    return null;
+  }
+}
+
+async function deleteVariableRecord(variable) {
+  if (!variable) return;
+  try {
+    await takaro.variable.variableControllerDelete(variable.id);
+  } catch (err) {
+    const status = err?.response?.status ?? err?.status;
+    if (status !== 404) throw err;
+  }
+}
+
+export async function acquireRaceLock(gameServerId, moduleId, reason = 'race-mutation') {
+  const owner = `${reason}:${Date.now()}:${Math.random().toString(36).slice(2)}`;
+  const existing = await findVariable(gameServerId, moduleId, RACING_LOCK_KEY);
+  const existingLock = parseVariableValue(existing);
+  const isExpired = existingLock?.expiresAt && existingLock.expiresAt < Date.now();
+
+  if (existing && isExpired) {
+    console.warn(`racing: reclaiming stale lock owner=${existingLock.owner || 'unknown'} reason=${existingLock.reason || 'unknown'}`);
+    await deleteVariableRecord(existing);
+  } else if (existing) {
+    throw new TakaroUserError('Race state is busy. Please try again in a moment.');
+  }
+
+  try {
+    await takaro.variable.variableControllerCreate({
+      key: RACING_LOCK_KEY,
+      value: JSON.stringify({
+        owner,
+        reason,
+        acquiredAt: Date.now(),
+        expiresAt: Date.now() + LOCK_TIMEOUT_MS,
+      }),
+      gameServerId,
+      moduleId,
+    });
+    return owner;
+  } catch (err) {
+    const status = err?.response?.status ?? err?.status;
+    if (status === 409) {
+      throw new TakaroUserError('Race state is busy. Please try again in a moment.');
+    }
+    throw err;
+  }
+}
+
+export async function releaseRaceLock(gameServerId, moduleId, owner) {
+  const existing = await findVariable(gameServerId, moduleId, RACING_LOCK_KEY);
+  const existingLock = parseVariableValue(existing);
+  if (existing && existingLock?.owner === owner) {
+    await deleteVariableRecord(existing);
+  }
+}
+
+export async function renewRaceLock(gameServerId, moduleId, owner) {
+  const existing = await findVariable(gameServerId, moduleId, RACING_LOCK_KEY);
+  const existingLock = parseVariableValue(existing);
+  if (!existing || existingLock?.owner !== owner) return false;
+
+  await takaro.variable.variableControllerUpdate(existing.id, {
+    value: JSON.stringify({
+      ...existingLock,
+      renewedAt: Date.now(),
+      expiresAt: Date.now() + LOCK_TIMEOUT_MS,
+    }),
+  });
+  return true;
+}
+
+export async function getRaceData(gameServerId, moduleId) {
+  const variable = await findVariable(gameServerId, moduleId, RACE_STATE_KEY);
+  if (!variable) {
+    const state = initialRaceState();
+    await writeVariable(gameServerId, moduleId, RACE_STATE_KEY, state);
+    return state;
+  }
+
+  try {
+    const parsed = JSON.parse(variable.value);
+    return {
+      ...initialRaceState(),
+      ...parsed,
+      bets: Array.isArray(parsed.bets) ? parsed.bets : [],
+      raceNumber: toPositiveInteger(parsed.raceNumber, 1),
+    };
+  } catch (err) {
+    console.error(`racing: failed to parse race state, resetting. Error: ${err}`);
+    const state = initialRaceState();
+    await writeVariable(gameServerId, moduleId, RACE_STATE_KEY, state);
+    return state;
+  }
+}
+
+export async function updateRaceData(gameServerId, moduleId, raceData) {
+  await writeVariable(gameServerId, moduleId, RACE_STATE_KEY, raceData);
+}
+
+export function simulateWeightedRace(entrants) {
+  const racers = entrants.length > 0 ? entrants : DEFAULT_ENTRANTS;
+  const totalWeight = racers.reduce((sum, entrant) => sum + (1 / Math.max(1, entrant.odds)), 0);
+  const random = Math.random() * totalWeight;
+  let cursor = 0;
+  let winnerIndex = 0;
+
+  for (let i = 0; i < racers.length; i++) {
+    cursor += 1 / Math.max(1, racers[i].odds);
+    if (random <= cursor) {
+      winnerIndex = i;
+      break;
+    }
+  }
+
+  const winner = racers[winnerIndex];
+  const others = racers
+    .filter((_, index) => index !== winnerIndex)
+    .map((entrant) => ({ ...entrant, score: Math.random() / Math.max(1, entrant.odds) }))
+    .sort((a, b) => b.score - a.score);
+
+  return [winner, ...others].map((entrant, index) => ({
+    name: entrant.name,
+    odds: entrant.odds,
+    position: index + 1,
+  }));
+}
+
+export function buildRaceResult(raceData, results, jackpotAmount = 0) {
+  const winner = results[0];
+  const allBets = Array.isArray(raceData.bets) ? raceData.bets : [];
+  const winners = allBets.filter((bet) => bet.racer.toLowerCase() === winner.name.toLowerCase());
+  let totalPayout = 0;
+
+  const paidWinners = winners.map((bet) => {
+    const payout = Math.floor(bet.amount * bet.odds) + (jackpotAmount > 0 ? Math.floor(jackpotAmount / winners.length) : 0);
+    totalPayout += payout;
+    return { ...bet, payout };
+  });
+
+  return {
+    raceNumber: raceData.raceNumber,
+    results,
+    winner: winner.name,
+    bets: allBets,
+    winners: paidWinners,
+    totalBets: allBets.length,
+    totalWagered: allBets.reduce((sum, bet) => sum + bet.amount, 0),
+    totalPayout,
+    jackpot: jackpotAmount,
+    timestamp: Date.now(),
+  };
+}
+
+export async function updatePlayerStats(gameServerId, moduleId, playerId, bet, isWin, winnings = 0, statUpdateId = null) {
+  const existing = await findVariable(gameServerId, moduleId, RACING_STATS_KEY, playerId);
+  let stats = {
+    playerName: bet.playerName,
+    totalWinnings: 0,
+    totalBets: 0,
+    totalWagered: 0,
+    wins: 0,
+    losses: 0,
+    biggestWin: 0,
+    favoriteRacer: bet.racer,
+    racerStats: {},
+    processedStatIds: [],
+  };
+
+  if (existing) {
+    try {
+      stats = { ...stats, ...JSON.parse(existing.value) };
+    } catch (err) {
+      console.error(`racing: failed to parse stats for player=${playerId}. Error: ${err}`);
+    }
+  }
+
+  stats.processedStatIds = normalizeProgressList(stats.processedStatIds);
+  if (statUpdateId && stats.processedStatIds.includes(statUpdateId)) return;
+
+  stats.playerName = bet.playerName;
+  stats.totalBets += 1;
+  stats.totalWagered += bet.amount;
+  if (isWin) {
+    stats.wins += 1;
+    stats.totalWinnings += winnings;
+    stats.biggestWin = Math.max(stats.biggestWin, winnings);
+  } else {
+    stats.losses += 1;
+  }
+
+  if (!stats.racerStats) stats.racerStats = {};
+  if (!stats.racerStats[bet.racer]) {
+    stats.racerStats[bet.racer] = { bets: 0, wins: 0, totalWagered: 0 };
+  }
+  stats.racerStats[bet.racer].bets += 1;
+  stats.racerStats[bet.racer].totalWagered += bet.amount;
+  if (isWin) stats.racerStats[bet.racer].wins += 1;
+
+  const favorite = Object.entries(stats.racerStats).sort(([, a], [, b]) => b.bets - a.bets)[0];
+  stats.favoriteRacer = favorite ? favorite[0] : bet.racer;
+  if (statUpdateId) {
+    stats.processedStatIds = [...stats.processedStatIds, statUpdateId].slice(-200);
+  }
+
+  await writeVariable(gameServerId, moduleId, RACING_STATS_KEY, stats, playerId);
+}
+
+export async function checkAndCreateJackpot(gameServerId, moduleId, totalWagered) {
+  if (totalWagered < 1000) return { isJackpot: false, amount: 0 };
+
+  const existing = await findVariable(gameServerId, moduleId, RACING_JACKPOT_KEY);
+  if (existing) {
+    try {
+      const jackpot = JSON.parse(existing.value);
+      if (jackpot.active && jackpot.amount > 0) return { isJackpot: true, amount: jackpot.amount };
+    } catch (err) {
+      console.error(`racing: failed to parse jackpot. Error: ${err}`);
+    }
+  }
+
+  const amount = Math.floor(totalWagered * 0.25);
+  await writeVariable(gameServerId, moduleId, RACING_JACKPOT_KEY, { active: true, amount, createdAt: Date.now() });
+  return { isJackpot: true, amount };
+}
+
+export async function clearJackpot(gameServerId, moduleId) {
+  const existing = await findVariable(gameServerId, moduleId, RACING_JACKPOT_KEY);
+  if (existing) await takaro.variable.variableControllerDelete(existing.id);
+}
+
+function normalizeProgressList(value) {
+  return Array.isArray(value) ? value.filter(Boolean) : [];
+}
+
+function hasCompletionProgress(completion, key, playerId) {
+  return normalizeProgressList(completion?.[key]).includes(playerId);
+}
+
+function withCompletionProgress(raceData, result, nextRaceData, updates = {}) {
+  const completion = raceData.completion?.raceNumber === result.raceNumber ? raceData.completion : {};
+  return {
+    ...raceData,
+    completion: {
+      ...completion,
+      raceNumber: result.raceNumber,
+      status: 'payout-pending',
+      result,
+      nextRaceData,
+      startedAt: completion.startedAt || Date.now(),
+      activeOwner: updates.activeOwner ?? completion.activeOwner,
+      activeExpiresAt: updates.activeExpiresAt ?? completion.activeExpiresAt,
+      payoutStartedPlayerIds: normalizeProgressList(updates.payoutStartedPlayerIds ?? completion.payoutStartedPlayerIds),
+      statsUpdatedPlayerIds: normalizeProgressList(updates.statsUpdatedPlayerIds ?? completion.statsUpdatedPlayerIds),
+      finalizedPlayerIds: normalizeProgressList(updates.finalizedPlayerIds ?? completion.finalizedPlayerIds),
+    },
+  };
+}
+
+function completionActiveLease(owner) {
+  return {
+    activeOwner: owner,
+    activeExpiresAt: Date.now() + COMPLETION_ACTIVE_TIMEOUT_MS,
+  };
+}
+
+function hasActiveCompletionLease(completion) {
+  return Boolean(completion?.activeExpiresAt && completion.activeExpiresAt > Date.now());
+}
+
+function raceCompletionBusyError(raceNumber) {
+  return new TakaroUserError(`Race #${raceNumber} completion is still in progress. Please try again in a moment.`);
+}
+
+async function refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData) {
+  if (lockOwner) await renewRaceLock(gameServerId, moduleId, lockOwner);
+  const updatedRaceData = withCompletionProgress(raceData, result, nextRaceData, completionActiveLease(lockOwner));
+  await updateRaceData(gameServerId, moduleId, updatedRaceData);
+  return updatedRaceData;
+}
+
+function buildNextRaceData(raceData, result) {
+  return {
+    nextRaceTime: Date.now() + (2 * 60 * 60 * 1000),
+    bets: [],
+    lastRaceResults: result,
+    raceNumber: raceData.raceNumber + 1,
+  };
+}
+
+export async function completeRace(gameServerId, moduleId, config) {
+  const requestedRaceNumber = (await getRaceData(gameServerId, moduleId)).raceNumber;
+  let lockOwner;
+  try {
+    try {
+      lockOwner = await acquireRaceLock(gameServerId, moduleId, 'complete-race');
+    } catch (err) {
+      if (err instanceof TakaroUserError) {
+        const raceData = await getRaceData(gameServerId, moduleId);
+        if (raceData.completion?.raceNumber === requestedRaceNumber) {
+          if (raceData.completion.status === 'completed') {
+            console.warn(`racing:completeRace duplicate completion returned completed journal result race=${requestedRaceNumber}`);
+            return {
+              result: raceData.completion.result,
+              nextRaceData: raceData.completion.nextRaceData || raceData,
+            };
+          }
+          console.warn(`racing:completeRace active completion is still busy race=${requestedRaceNumber} status=${raceData.completion.status}`);
+          throw raceCompletionBusyError(requestedRaceNumber);
+        }
+        if (raceData.raceNumber !== requestedRaceNumber && raceData.lastRaceResults?.raceNumber === requestedRaceNumber) {
+          console.warn(`racing:completeRace duplicate completion returned completed result race=${requestedRaceNumber}`);
+          return {
+            result: raceData.lastRaceResults,
+            nextRaceData: raceData,
+          };
+        }
+        if (raceData.lastRaceResults?.raceNumber === requestedRaceNumber) {
+          console.warn(`racing:completeRace duplicate completion returned completed result race=${requestedRaceNumber}`);
+          return {
+            result: raceData.lastRaceResults,
+            nextRaceData: raceData,
+          };
+        }
+      }
+      throw err;
+    }
+
+    let raceData = await getRaceData(gameServerId, moduleId);
+    if (raceData.raceNumber !== requestedRaceNumber && raceData.lastRaceResults?.raceNumber === requestedRaceNumber) {
+      console.warn(`racing:completeRace duplicate completion ignored race=${requestedRaceNumber} already advancedTo=${raceData.raceNumber}`);
+      return {
+        result: raceData.lastRaceResults,
+        nextRaceData: raceData,
+      };
+    }
+
+    let result;
+    let nextRaceData;
+    let jackpot = { isJackpot: false, amount: 0 };
+    if (raceData.completion?.raceNumber === raceData.raceNumber) {
+      if (hasActiveCompletionLease(raceData.completion)) {
+        console.warn(`racing:completeRace active completion is still busy race=${raceData.raceNumber} owner=${raceData.completion.activeOwner || 'unknown'}`);
+        throw raceCompletionBusyError(raceData.raceNumber);
+      }
+      if (raceData.completion.status === 'completed') {
+        console.warn(`racing:completeRace duplicate completion ignored race=${raceData.raceNumber} status=completed`);
+        return {
+          result: raceData.completion.result,
+          nextRaceData: raceData,
+        };
+      }
+      console.warn(`racing:completeRace retrying pending finalization race=${raceData.raceNumber} status=${raceData.completion.status}`);
+      result = raceData.completion.result;
+      nextRaceData = raceData.completion.nextRaceData || buildNextRaceData(raceData, result);
+      jackpot = { isJackpot: result.jackpot > 0, amount: result.jackpot || 0 };
+      raceData = withCompletionProgress(raceData, result, nextRaceData, completionActiveLease(lockOwner));
+      await updateRaceData(gameServerId, moduleId, raceData);
+    } else {
+      const entrants = parseEntrants(config);
+      const results = simulateWeightedRace(entrants);
+      const totalWagered = raceData.bets.reduce((sum, bet) => sum + bet.amount, 0);
+      jackpot = raceData.bets.length > 0 ? await checkAndCreateJackpot(gameServerId, moduleId, totalWagered) : { isJackpot: false, amount: 0 };
+      result = buildRaceResult(raceData, results, jackpot.isJackpot ? jackpot.amount : 0);
+      nextRaceData = buildNextRaceData(raceData, result);
+      raceData = withCompletionProgress(raceData, result, nextRaceData, completionActiveLease(lockOwner));
+      await updateRaceData(gameServerId, moduleId, raceData);
+    }
+
+    for (const bet of result.bets) {
+      raceData = await refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData);
+      if (hasCompletionProgress(raceData.completion, 'finalizedPlayerIds', bet.playerId)) continue;
+
+      const winningBet = result.winners.find((winner) => winner.playerId === bet.playerId);
+      if (winningBet && !hasCompletionProgress(raceData.completion, 'payoutStartedPlayerIds', bet.playerId)) {
+        const payoutStartedPlayerIds = [...normalizeProgressList(raceData.completion.payoutStartedPlayerIds), bet.playerId];
+        raceData = withCompletionProgress(raceData, result, nextRaceData, { ...completionActiveLease(lockOwner), payoutStartedPlayerIds });
+        await updateRaceData(gameServerId, moduleId, raceData);
+        try {
+          await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, bet.playerId, {
+            currency: winningBet.payout,
+          });
+        } catch (err) {
+          raceData = withCompletionProgress(raceData, result, nextRaceData, {
+            ...completionActiveLease(lockOwner),
+            payoutStartedPlayerIds: normalizeProgressList(raceData.completion.payoutStartedPlayerIds).filter((playerId) => playerId !== bet.playerId),
+          });
+          await updateRaceData(gameServerId, moduleId, raceData);
+          throw err;
+        }
+      }
+
+      raceData = await refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData);
+      if (!hasCompletionProgress(raceData.completion, 'statsUpdatedPlayerIds', bet.playerId)) {
+        const statUpdateId = `${result.raceNumber}:${bet.playerId}`;
+        if (winningBet) {
+          await updatePlayerStats(gameServerId, moduleId, bet.playerId, bet, true, winningBet.payout, statUpdateId);
+        } else {
+          await updatePlayerStats(gameServerId, moduleId, bet.playerId, bet, false, 0, statUpdateId);
+        }
+
+        raceData = await refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData);
+        const statsUpdatedPlayerIds = [...normalizeProgressList(raceData.completion.statsUpdatedPlayerIds), bet.playerId];
+        raceData = withCompletionProgress(raceData, result, nextRaceData, { ...completionActiveLease(lockOwner), statsUpdatedPlayerIds });
+        await updateRaceData(gameServerId, moduleId, raceData);
+      }
+
+      raceData = await refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData);
+      const finalizedPlayerIds = [...normalizeProgressList(raceData.completion.finalizedPlayerIds), bet.playerId];
+      raceData = withCompletionProgress(raceData, result, nextRaceData, { ...completionActiveLease(lockOwner), finalizedPlayerIds });
+      await updateRaceData(gameServerId, moduleId, raceData);
+    }
+
+    raceData = await refreshCompletionLease(gameServerId, moduleId, lockOwner, raceData, result, nextRaceData);
+    if (jackpot.isJackpot) await clearJackpot(gameServerId, moduleId);
+
+    const completedRaceData = {
+      ...nextRaceData,
+      completion: {
+        ...raceData.completion,
+        raceNumber: result.raceNumber,
+        status: 'completed',
+        result,
+        completedAt: Date.now(),
+      },
+    };
+    await updateRaceData(gameServerId, moduleId, completedRaceData);
+
+    return { result, nextRaceData: completedRaceData };
+  } finally {
+    if (lockOwner) await releaseRaceLock(gameServerId, moduleId, lockOwner);
+  }
+}

--- a/modules/zombie-racing/test/zombie-racing.test.ts
+++ b/modules/zombie-racing/test/zombie-racing.test.ts
@@ -1,0 +1,822 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+type ExecutionResult = {
+  success: boolean;
+  logs: string[];
+};
+
+type RaceState = {
+  raceNumber: number;
+  nextRaceTime: number;
+  bets: Array<{ playerId: string; playerName: string; racer: string; odds: number; amount: number }>;
+  lastRaceResults?: RaceResult | null;
+  completion?: {
+    raceNumber: number;
+    status: string;
+    result: RaceResult;
+    nextRaceData: RaceState;
+    activeOwner?: string;
+    activeExpiresAt?: number;
+    payoutStartedPlayerIds?: string[];
+    statsUpdatedPlayerIds?: string[];
+    finalizedPlayerIds?: string[];
+  } | null;
+};
+
+type RaceResult = {
+  raceNumber: number;
+  results: Array<{ name: string; odds: number; position: number }>;
+  winner: string;
+  bets: RaceState['bets'];
+  winners: Array<RaceState['bets'][number] & { payout: number }>;
+  totalBets: number;
+  totalWagered: number;
+  totalPayout: number;
+  jackpot: number;
+  timestamp: number;
+};
+
+type PlayerRaceStats = {
+  playerName: string;
+  totalWinnings: number;
+  totalBets: number;
+  totalWagered: number;
+  wins: number;
+  losses: number;
+  biggestWin: number;
+  favoriteRacer: string;
+  racerStats: Record<string, { bets: number; wins: number; totalWagered: number }>;
+  processedStatIds?: string[];
+};
+
+describe('zombie-racing: commands and race flow', () => {
+  let client: Client;
+  let ctx: MockServerContext;
+  let moduleId: string;
+  let versionId: string;
+  let prefix: string;
+  let runRaceCronjobId: string;
+  let betAdminRoleId: string | undefined;
+  let betOnlyRoleId: string | undefined;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client, { totalPlayers: 2 });
+
+    await client.settings.settingsControllerSet('economyEnabled', {
+      gameServerId: ctx.gameServer.id,
+      value: 'true',
+    });
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        minBet: 25,
+        maxBet: 250,
+      },
+    });
+
+    const runRaceCronjob = mod.latestVersion.cronJobs.find((cronjob) => cronjob.name === 'runRace');
+    assert.ok(runRaceCronjob, 'Expected runRace cronjob to be present');
+    runRaceCronjobId = runRaceCronjob.id;
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    betAdminRoleId = await assignPermissions(client, ctx.players[0].playerId, ctx.gameServer.id, [
+      'RACING_BET',
+      'RACING_ADMIN',
+    ]);
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 300 },
+    );
+  });
+
+  after(async () => {
+    await cleanupRole(client, betAdminRoleId);
+    await cleanupRole(client, betOnlyRoleId);
+    if (moduleId && ctx?.gameServer?.id) {
+      try {
+        await uninstallModule(client, moduleId, ctx.gameServer.id);
+      } catch (err) {
+        console.error('Cleanup: failed to uninstall zombie-racing module:', err);
+      }
+    }
+    if (moduleId) {
+      try {
+        await deleteModule(client, moduleId);
+      } catch (err) {
+        console.error('Cleanup: failed to delete zombie-racing module:', err);
+      }
+    }
+    if (ctx?.server) await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  async function triggerCommand(playerId: string, command: string): Promise<ExecutionResult> {
+    const before = new Date();
+    await client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}${command}`,
+      playerId,
+    });
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    return {
+      success: meta?.result?.success ?? false,
+      logs: (meta?.result?.logs ?? []).map((log) => log.msg),
+    };
+  }
+
+  async function triggerRunRace(): Promise<ExecutionResult> {
+    const before = new Date();
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx.gameServer.id,
+      cronjobId: runRaceCronjobId,
+      moduleId,
+    });
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+    const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+    return {
+      success: meta?.result?.success ?? false,
+      logs: (meta?.result?.logs ?? []).map((log) => log.msg),
+    };
+  }
+
+  async function waitForEvents(eventName: EventSearchInputAllowedFiltersEventNameEnum, after: Date, count: number) {
+    const deadline = Date.now() + 30000;
+    while (Date.now() < deadline) {
+      const result = await client.event.eventControllerSearch({
+        filters: {
+          eventName: [eventName],
+          gameserverId: [ctx.gameServer.id],
+        },
+        greaterThan: {
+          createdAt: after.toISOString(),
+        },
+      });
+      if (result.data.data.length >= count) return result.data.data;
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+    throw new Error(`Timed out waiting for ${count} ${eventName} events`);
+  }
+
+  async function triggerCommandsConcurrently(commands: Array<{ playerId: string; command: string }>): Promise<ExecutionResult[]> {
+    const before = new Date();
+    await Promise.all(commands.map(({ playerId, command }) => client.command.commandControllerTrigger(ctx.gameServer.id, {
+      msg: `${prefix}${command}`,
+      playerId,
+    })));
+    const events = await waitForEvents(EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted, before, commands.length);
+    return events.slice(0, commands.length).map((event) => {
+      const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+      return {
+        success: meta?.result?.success ?? false,
+        logs: (meta?.result?.logs ?? []).map((log) => log.msg),
+      };
+    });
+  }
+
+  async function triggerRunRaceAndCommandConcurrently(commandPlayerId: string, command: string): Promise<ExecutionResult[]> {
+    const cronBefore = new Date();
+    const commandBefore = new Date();
+    await Promise.all([
+      client.cronjob.cronJobControllerTrigger({
+        gameServerId: ctx.gameServer.id,
+        cronjobId: runRaceCronjobId,
+        moduleId,
+      }),
+      client.command.commandControllerTrigger(ctx.gameServer.id, {
+        msg: `${prefix}${command}`,
+        playerId: commandPlayerId,
+      }),
+    ]);
+    const [cronEvent, commandEvent] = await Promise.all([
+      waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+        gameserverId: ctx.gameServer.id,
+        after: cronBefore,
+        timeout: 30000,
+      }),
+      waitForEvent(client, {
+        eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+        gameserverId: ctx.gameServer.id,
+        after: commandBefore,
+        timeout: 30000,
+      }),
+    ]);
+    return [cronEvent, commandEvent].map((event) => {
+      const meta = event.meta as { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+      return {
+        success: meta?.result?.success ?? false,
+        logs: (meta?.result?.logs ?? []).map((log) => log.msg),
+      };
+    });
+  }
+
+  async function getRaceState(): Promise<RaceState> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: ['zombie_racing_state_v1'],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+      },
+    });
+    assert.ok(vars.data.data[0], 'Expected zombie racing state variable to exist');
+    return JSON.parse(vars.data.data[0].value) as RaceState;
+  }
+
+  async function setRaceState(state: RaceState): Promise<void> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: ['zombie_racing_state_v1'],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+      },
+    });
+    assert.ok(vars.data.data[0], 'Expected zombie racing state variable to exist');
+    await client.variable.variableControllerUpdate(vars.data.data[0].id, {
+      value: JSON.stringify(state),
+    });
+  }
+
+  async function getPlayerStats(playerId: string): Promise<PlayerRaceStats | null> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: ['zombie_racing_stats_v1'],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+        playerId: [playerId],
+      },
+    });
+    if (!vars.data.data[0]) return null;
+    return JSON.parse(vars.data.data[0].value) as PlayerRaceStats;
+  }
+
+  async function setPlayerStats(playerId: string, stats: PlayerRaceStats): Promise<void> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: ['zombie_racing_stats_v1'],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+        playerId: [playerId],
+      },
+    });
+    if (vars.data.data[0]) {
+      await client.variable.variableControllerUpdate(vars.data.data[0].id, {
+        value: JSON.stringify(stats),
+      });
+      return;
+    }
+
+    await client.variable.variableControllerCreate({
+      key: 'zombie_racing_stats_v1',
+      value: JSON.stringify(stats),
+      gameServerId: ctx.gameServer.id,
+      moduleId,
+      playerId,
+    });
+  }
+
+  async function createStaleRaceLock(owner: string): Promise<void> {
+    const vars = await client.variable.variableControllerSearch({
+      filters: {
+        key: ['zombie_racing_lock_v1'],
+        gameServerId: [ctx.gameServer.id],
+        moduleId: [moduleId],
+      },
+    });
+    await Promise.all(vars.data.data.map((variable) => client.variable.variableControllerDelete(variable.id)));
+    await client.variable.variableControllerCreate({
+      key: 'zombie_racing_lock_v1',
+      value: JSON.stringify({
+        owner,
+        reason: 'complete-race',
+        acquiredAt: Date.now() - 60000,
+        expiresAt: Date.now() - 30000,
+      }),
+      gameServerId: ctx.gameServer.id,
+      moduleId,
+    });
+  }
+
+  async function getCurrency(playerId: string): Promise<number> {
+    const pog = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [playerId] },
+    });
+    return pog.data.data[0]?.currency ?? 0;
+  }
+
+  it('lists default zombie-themed racers and bet limits', async () => {
+    const result = await triggerCommand(ctx.players[0].playerId, 'racers');
+
+    assert.equal(result.success, true, `Expected /racers to succeed, logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('Zombie Race')), `Expected race name in logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('label=zombies')), `Expected zombie label in logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('Biker:2')), `Expected default entrant in logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('minBet=25') && msg.includes('maxBet=250')), `Expected configured limits in logs: ${JSON.stringify(result.logs)}`);
+  });
+
+  it('denies race betting without RACING_BET permission', async () => {
+    const result = await triggerCommand(ctx.players[1].playerId, 'racebet Biker 50');
+
+    assert.equal(result.success, false, 'Expected /racebet to fail without permission');
+    assert.ok(result.logs.some((msg) => msg.includes('permission')), `Expected permission error, got: ${JSON.stringify(result.logs)}`);
+  });
+
+  it('validates entrant names and bet limits', async () => {
+    const badEntrant = await triggerCommand(ctx.players[0].playerId, 'racebet Missing 50');
+    assert.equal(badEntrant.success, false, 'Expected missing entrant to fail');
+    assert.ok(badEntrant.logs.some((msg) => msg.includes('was not found')), `Expected entrant error, got: ${JSON.stringify(badEntrant.logs)}`);
+
+    const tooSmall = await triggerCommand(ctx.players[0].playerId, 'racebet Biker 10');
+    assert.equal(tooSmall.success, false, 'Expected too-small bet to fail');
+    assert.ok(tooSmall.logs.some((msg) => msg.includes('between 25 and 250')), `Expected range error, got: ${JSON.stringify(tooSmall.logs)}`);
+
+    const tooLarge = await triggerCommand(ctx.players[0].playerId, 'racebet Biker 300');
+    assert.equal(tooLarge.success, false, 'Expected too-large bet to fail');
+    assert.ok(tooLarge.logs.some((msg) => msg.includes('between 25 and 250')), `Expected range error, got: ${JSON.stringify(tooLarge.logs)}`);
+  });
+
+  it('rejects race betting when the player lacks currency', async () => {
+    betOnlyRoleId = await assignPermissions(client, ctx.players[1].playerId, ctx.gameServer.id, [
+      'RACING_BET',
+    ]);
+
+    const result = await triggerCommand(ctx.players[1].playerId, 'racebet Biker 50');
+
+    assert.equal(result.success, false, 'Expected insufficient currency to fail');
+    assert.ok(result.logs.some((msg) => msg.includes("don't have enough currency")), `Expected currency error, got: ${JSON.stringify(result.logs)}`);
+  });
+
+  it('places a bet and replaces an existing bet with a refund', async () => {
+    const player = ctx.players[0];
+
+    const before = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const startingCurrency = before.data.data[0]?.currency ?? 0;
+
+    const firstBet = await triggerCommand(player.playerId, 'racebet Biker 250');
+    assert.equal(firstBet.success, true, `Expected first bet to succeed, logs: ${JSON.stringify(firstBet.logs)}`);
+    assert.ok(firstBet.logs.some((msg) => msg.includes('racing:racebet') && msg.includes('racer=Biker') && msg.includes('amount=250')), `Expected bet confirmation, got: ${JSON.stringify(firstBet.logs)}`);
+
+    const replacementBet = await triggerCommand(player.playerId, 'racebet Arlene 100');
+    assert.equal(replacementBet.success, true, `Expected replacement bet to succeed, logs: ${JSON.stringify(replacementBet.logs)}`);
+    assert.ok(replacementBet.logs.some((msg) => msg.includes('add-currency')), `Expected refund API call, got: ${JSON.stringify(replacementBet.logs)}`);
+    assert.ok(replacementBet.logs.some((msg) => msg.includes('racing:racebet') && msg.includes('racer=Arlene') && msg.includes('amount=100')), `Expected replacement confirmation, got: ${JSON.stringify(replacementBet.logs)}`);
+
+    const after = await client.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: { gameServerId: [ctx.gameServer.id], playerId: [player.playerId] },
+    });
+    const endingCurrency = after.data.data[0]?.currency ?? 0;
+    assert.equal(endingCurrency, startingCurrency - 100, 'Expected old bet refund before replacement deduction');
+  });
+
+  it('shows current bets and next race without runtime errors', async () => {
+    const bets = await triggerCommand(ctx.players[0].playerId, 'myracebets');
+    assert.equal(bets.success, true, `Expected /myracebets to succeed, logs: ${JSON.stringify(bets.logs)}`);
+    assert.ok(bets.logs.some((msg) => msg.includes('racing:myracebets') && msg.includes('racers=Arlene')), `Expected current bet output, got: ${JSON.stringify(bets.logs)}`);
+
+    const nextRace = await triggerCommand(ctx.players[0].playerId, 'nextrace');
+    assert.equal(nextRace.success, true, `Expected /nextrace to succeed, logs: ${JSON.stringify(nextRace.logs)}`);
+    assert.ok(nextRace.logs.some((msg) => msg.includes('racing:nextrace') && msg.includes('playerBets=Arlene:100')), `Expected canonical racer field in output, got: ${JSON.stringify(nextRace.logs)}`);
+  });
+
+  it('serializes concurrent race bets without dropping paid wagers', async () => {
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[1].playerId,
+      { currency: 100 },
+    );
+
+    const results = await triggerCommandsConcurrently([
+      { playerId: ctx.players[0].playerId, command: 'racebet Chuck 75' },
+      { playerId: ctx.players[1].playerId, command: 'racebet Biker 50' },
+    ]);
+
+    assert.ok(results.some((result) => result.success), `Expected at least one concurrent bet to succeed, got: ${JSON.stringify(results)}`);
+    assert.equal(
+      results.filter((result) => !result.success).every((result) => result.logs.some((msg) => msg.includes('Race state is busy'))),
+      true,
+      `Expected any rejected overlapping bet to fail before mutating state, got: ${JSON.stringify(results)}`,
+    );
+    const state = await getRaceState();
+    const player0Bet = state.bets.find((bet) => bet.playerId === ctx.players[0].playerId);
+    const player1Bet = state.bets.find((bet) => bet.playerId === ctx.players[1].playerId);
+    const player0Succeeded = results.some((result) => result.logs.some((msg) => msg.includes('racer=Chuck') && msg.includes('amount=75')));
+    const player1Succeeded = results.some((result) => result.logs.some((msg) => msg.includes('racer=Biker') && msg.includes('amount=50')));
+
+    assert.ok(player0Bet, `Expected player 0 to retain a wager, got: ${JSON.stringify(state.bets)}`);
+    assert.equal(player0Bet.racer, player0Succeeded ? 'Chuck' : 'Arlene', `Expected player 0 state to match successful replacement result, got: ${JSON.stringify(state.bets)}`);
+    assert.equal(player0Bet.amount, player0Succeeded ? 75 : 100, `Expected player 0 amount to match successful replacement result, got: ${JSON.stringify(state.bets)}`);
+    if (player1Succeeded) {
+      assert.ok(player1Bet, `Expected player 1 successful wager to remain in race state, got: ${JSON.stringify(state.bets)}`);
+      assert.equal(player1Bet.racer, 'Biker');
+      assert.equal(player1Bet.amount, 50);
+    } else {
+      assert.equal(player1Bet, undefined, `Expected rejected player 1 wager not to be persisted, got: ${JSON.stringify(state.bets)}`);
+    }
+  });
+
+  it('runs a race, records the result, clears current bets, and updates stats', async () => {
+    const race = await triggerRunRace();
+    assert.equal(race.success, true, `Expected runRace to succeed, logs: ${JSON.stringify(race.logs)}`);
+    assert.ok(race.logs.some((msg) => msg.includes('racing:runRace')), `Expected runRace log, got: ${JSON.stringify(race.logs)}`);
+
+    const lastRace = await triggerCommand(ctx.players[0].playerId, 'lastrace');
+    assert.equal(lastRace.success, true, `Expected /lastrace to succeed, logs: ${JSON.stringify(lastRace.logs)}`);
+    assert.ok(
+      lastRace.logs.some((msg) => msg.includes('racing:lastrace') && (msg.includes('totalBets=1') || msg.includes('totalBets=2'))),
+      `Expected full bet count in last race, got: ${JSON.stringify(lastRace.logs)}`,
+    );
+
+    const myBets = await triggerCommand(ctx.players[0].playerId, 'myracebets');
+    assert.equal(myBets.success, true, `Expected /myracebets after race to succeed, logs: ${JSON.stringify(myBets.logs)}`);
+    assert.ok(myBets.logs.some((msg) => msg.includes('racing:myracebets') && msg.includes('bets=0')), `Expected bets to be cleared, got: ${JSON.stringify(myBets.logs)}`);
+
+    const stats = await triggerCommand(ctx.players[0].playerId, 'racestats');
+    assert.equal(stats.success, true, `Expected /racestats to succeed, logs: ${JSON.stringify(stats.logs)}`);
+    assert.ok(stats.logs.some((msg) => msg.includes('racing:racestats') && msg.includes('bets=1')), `Expected stats to record bet, got: ${JSON.stringify(stats.logs)}`);
+
+    const leaderboard = await triggerCommand(ctx.players[0].playerId, 'raceleaderboard');
+    assert.equal(leaderboard.success, true, `Expected /raceleaderboard to succeed, logs: ${JSON.stringify(leaderboard.logs)}`);
+    assert.ok(leaderboard.logs.some((msg) => msg.includes('leaderboard')), `Expected leaderboard output, got: ${JSON.stringify(leaderboard.logs)}`);
+  });
+
+  it('allows admin-triggered no-bet races to complete', async () => {
+    const result = await triggerCommand(ctx.players[0].playerId, 'startrace');
+
+    assert.equal(result.success, true, `Expected no-bet /startrace to succeed, logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('racing:startrace') && msg.includes('bets=0')), `Expected no-bet completion output, got: ${JSON.stringify(result.logs)}`);
+  });
+
+  it('does not double-pay when race completion is triggered concurrently', async () => {
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        entrants: ['Solo; 2'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 100 },
+    );
+
+    const bet = await triggerCommand(ctx.players[0].playerId, 'racebet Solo 50');
+    assert.equal(bet.success, true, `Expected single-racer bet to succeed, logs: ${JSON.stringify(bet.logs)}`);
+    const beforeCompletionCurrency = await getCurrency(ctx.players[0].playerId);
+    const raceBeforeCompletion = await getRaceState();
+
+    const results = await triggerRunRaceAndCommandConcurrently(ctx.players[0].playerId, 'startrace');
+
+    assert.equal(
+      results.every((result) => result.success || result.logs.some((msg) => msg.includes('completion is still in progress') || msg.includes('Race state is busy'))),
+      true,
+      `Expected overlapping completion triggers to complete once or report busy, got: ${JSON.stringify(results)}`,
+    );
+    const afterCompletionCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.ok(
+      afterCompletionCurrency === beforeCompletionCurrency || afterCompletionCurrency === beforeCompletionCurrency + 100,
+      `Expected overlapping completion not to double-pay, before=${beforeCompletionCurrency} after=${afterCompletionCurrency}`,
+    );
+
+    let state = await getRaceState();
+    if (state.raceNumber === raceBeforeCompletion.raceNumber) {
+      if (state.completion?.activeExpiresAt) {
+        await setRaceState({
+          ...state,
+          completion: {
+            ...state.completion,
+            activeExpiresAt: Date.now() - 1000,
+          },
+        });
+      }
+      const recovery = await triggerRunRace();
+      assert.equal(recovery.success, true, `Expected any pending overlapped completion to recover, logs: ${JSON.stringify(recovery.logs)}`);
+    }
+    const afterRecoveryCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.equal(afterRecoveryCurrency, beforeCompletionCurrency + 100, 'Expected exactly one winning payout after overlap recovery');
+
+    state = await getRaceState();
+    assert.equal(state.lastRaceResults?.totalBets, 1, `Expected original race result to be retained, got: ${JSON.stringify(state.lastRaceResults)}`);
+
+    const stats = await triggerCommand(ctx.players[0].playerId, 'racestats');
+    assert.equal(stats.success, true, `Expected /racestats to succeed, logs: ${JSON.stringify(stats.logs)}`);
+    assert.ok(stats.logs.some((msg) => msg.includes('racing:racestats') && msg.includes('bets=2')), `Expected stats to include one prior race and one idempotent completion bet, got: ${JSON.stringify(stats.logs)}`);
+  });
+
+  it('recovers stranded payout-pending race completion without double-paying', async () => {
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        entrants: ['Solo; 2'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 50 },
+    );
+
+    const bet = await triggerCommand(ctx.players[0].playerId, 'racebet Solo 50');
+    assert.equal(bet.success, true, `Expected single-racer bet to succeed, logs: ${JSON.stringify(bet.logs)}`);
+    const beforeRecoveryCurrency = await getCurrency(ctx.players[0].playerId);
+    const pendingState = await getRaceState();
+    const result: RaceResult = {
+      raceNumber: pendingState.raceNumber,
+      results: [{ name: 'Solo', odds: 2, position: 1 }],
+      winner: 'Solo',
+      bets: pendingState.bets,
+      winners: pendingState.bets.map((pendingBet) => ({ ...pendingBet, payout: pendingBet.amount * pendingBet.odds })),
+      totalBets: pendingState.bets.length,
+      totalWagered: pendingState.bets.reduce((sum, pendingBet) => sum + pendingBet.amount, 0),
+      totalPayout: pendingState.bets.reduce((sum, pendingBet) => sum + (pendingBet.amount * pendingBet.odds), 0),
+      jackpot: 0,
+      timestamp: Date.now(),
+    };
+    const nextRaceData: RaceState = {
+      nextRaceTime: Date.now() + (2 * 60 * 60 * 1000),
+      bets: [],
+      lastRaceResults: result,
+      raceNumber: pendingState.raceNumber + 1,
+    };
+    await setRaceState({
+      ...pendingState,
+      completion: {
+        raceNumber: pendingState.raceNumber,
+        status: 'payout-pending',
+        result,
+        nextRaceData,
+      },
+    });
+
+    const recovery = await triggerRunRace();
+    assert.equal(recovery.success, true, `Expected retry of pending completion to succeed, logs: ${JSON.stringify(recovery.logs)}`);
+    const afterRecoveryCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.equal(afterRecoveryCurrency, beforeRecoveryCurrency + 100, 'Expected retry to pay the stranded winner exactly once');
+
+    const completedState = await getRaceState();
+    assert.equal(completedState.raceNumber, pendingState.raceNumber + 1, `Expected race to advance after recovery, got: ${JSON.stringify(completedState)}`);
+    assert.equal(completedState.lastRaceResults?.raceNumber, pendingState.raceNumber, `Expected recovered result to become last race, got: ${JSON.stringify(completedState.lastRaceResults)}`);
+
+    const duplicate = await triggerRunRace();
+    assert.equal(duplicate.success, true, `Expected duplicate completion after recovery to succeed, logs: ${JSON.stringify(duplicate.logs)}`);
+    const afterDuplicateCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.equal(afterDuplicateCurrency, afterRecoveryCurrency, 'Expected duplicate completion not to pay the recovered winner again');
+  });
+
+  it('does not update stats twice when recovering after stats were written before finalization', async () => {
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        entrants: ['Solo; 2', 'Other; 2'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 50 },
+    );
+
+    const bet = await triggerCommand(ctx.players[0].playerId, 'racebet Solo 50');
+    assert.equal(bet.success, true, `Expected bet to succeed, logs: ${JSON.stringify(bet.logs)}`);
+    const pendingState = await getRaceState();
+    const [pendingBet] = pendingState.bets;
+    assert.ok(pendingBet, `Expected pending bet in race state, got: ${JSON.stringify(pendingState)}`);
+    const result: RaceResult = {
+      raceNumber: pendingState.raceNumber,
+      results: [
+        { name: 'Other', odds: 2, position: 1 },
+        { name: 'Solo', odds: 2, position: 2 },
+      ],
+      winner: 'Other',
+      bets: pendingState.bets,
+      winners: [],
+      totalBets: pendingState.bets.length,
+      totalWagered: pendingState.bets.reduce((sum, stateBet) => sum + stateBet.amount, 0),
+      totalPayout: 0,
+      jackpot: 0,
+      timestamp: Date.now(),
+    };
+    const nextRaceData: RaceState = {
+      nextRaceTime: Date.now() + (2 * 60 * 60 * 1000),
+      bets: [],
+      lastRaceResults: result,
+      raceNumber: pendingState.raceNumber + 1,
+    };
+    const statUpdateId = `${pendingState.raceNumber}:${pendingBet.playerId}`;
+    const existingStats = await getPlayerStats(pendingBet.playerId);
+    const statsAfterCrash: PlayerRaceStats = {
+      playerName: pendingBet.playerName,
+      totalWinnings: existingStats?.totalWinnings ?? 0,
+      totalBets: (existingStats?.totalBets ?? 0) + 1,
+      totalWagered: (existingStats?.totalWagered ?? 0) + pendingBet.amount,
+      wins: existingStats?.wins ?? 0,
+      losses: (existingStats?.losses ?? 0) + 1,
+      biggestWin: existingStats?.biggestWin ?? 0,
+      favoriteRacer: pendingBet.racer,
+      racerStats: {
+        ...(existingStats?.racerStats ?? {}),
+        [pendingBet.racer]: {
+          bets: ((existingStats?.racerStats ?? {})[pendingBet.racer]?.bets ?? 0) + 1,
+          wins: (existingStats?.racerStats ?? {})[pendingBet.racer]?.wins ?? 0,
+          totalWagered: ((existingStats?.racerStats ?? {})[pendingBet.racer]?.totalWagered ?? 0) + pendingBet.amount,
+        },
+      },
+      processedStatIds: [...(existingStats?.processedStatIds ?? []), statUpdateId],
+    };
+    await setPlayerStats(pendingBet.playerId, statsAfterCrash);
+    await setRaceState({
+      ...pendingState,
+      completion: {
+        raceNumber: pendingState.raceNumber,
+        status: 'payout-pending',
+        result,
+        nextRaceData,
+      },
+    });
+
+    const recovery = await triggerRunRace();
+    assert.equal(recovery.success, true, `Expected stats recovery to succeed, logs: ${JSON.stringify(recovery.logs)}`);
+    const recoveredStats = await getPlayerStats(pendingBet.playerId);
+    assert.equal(recoveredStats?.totalBets, statsAfterCrash.totalBets, `Expected recovery not to count stats twice, got: ${JSON.stringify(recoveredStats)}`);
+    assert.equal(recoveredStats?.losses, statsAfterCrash.losses, `Expected recovery not to duplicate loss stats, got: ${JSON.stringify(recoveredStats)}`);
+    const completedState = await getRaceState();
+    assert.ok(completedState.completion?.statsUpdatedPlayerIds?.includes(pendingBet.playerId), `Expected completion journal to record stats update, got: ${JSON.stringify(completedState.completion)}`);
+    assert.ok(completedState.completion?.finalizedPlayerIds?.includes(pendingBet.playerId), `Expected completion journal to finalize player, got: ${JSON.stringify(completedState.completion)}`);
+  });
+
+  it('does not resume an active long-running completion after the outer lock expires', async () => {
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        entrants: ['Solo; 2'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+    await client.playerOnGameserver.playerOnGameServerControllerAddCurrency(
+      ctx.gameServer.id,
+      ctx.players[0].playerId,
+      { currency: 50 },
+    );
+
+    const bet = await triggerCommand(ctx.players[0].playerId, 'racebet Solo 50');
+    assert.equal(bet.success, true, `Expected single-racer bet to succeed, logs: ${JSON.stringify(bet.logs)}`);
+    const beforeRetryCurrency = await getCurrency(ctx.players[0].playerId);
+    const pendingState = await getRaceState();
+    const result: RaceResult = {
+      raceNumber: pendingState.raceNumber,
+      results: [{ name: 'Solo', odds: 2, position: 1 }],
+      winner: 'Solo',
+      bets: pendingState.bets,
+      winners: pendingState.bets.map((pendingBet) => ({ ...pendingBet, payout: pendingBet.amount * pendingBet.odds })),
+      totalBets: pendingState.bets.length,
+      totalWagered: pendingState.bets.reduce((sum, pendingBet) => sum + pendingBet.amount, 0),
+      totalPayout: pendingState.bets.reduce((sum, pendingBet) => sum + (pendingBet.amount * pendingBet.odds), 0),
+      jackpot: 0,
+      timestamp: Date.now(),
+    };
+    const nextRaceData: RaceState = {
+      nextRaceTime: Date.now() + (2 * 60 * 60 * 1000),
+      bets: [],
+      lastRaceResults: result,
+      raceNumber: pendingState.raceNumber + 1,
+    };
+    await setRaceState({
+      ...pendingState,
+      completion: {
+        raceNumber: pendingState.raceNumber,
+        status: 'payout-pending',
+        result,
+        nextRaceData,
+        activeOwner: 'still-running-completion',
+        activeExpiresAt: Date.now() + (5 * 60 * 1000),
+      },
+    });
+    await createStaleRaceLock('expired-outer-lock');
+
+    const activeRetry = await triggerRunRace();
+    assert.equal(activeRetry.success, false, `Expected active completion retry to report busy, logs: ${JSON.stringify(activeRetry.logs)}`);
+    assert.ok(activeRetry.logs.some((msg) => msg.includes('completion is still in progress')), `Expected busy completion output, got: ${JSON.stringify(activeRetry.logs)}`);
+    const afterActiveRetryCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.equal(afterActiveRetryCurrency, beforeRetryCurrency, 'Expected active completion retry not to pay while another invocation is still leased');
+    const stillPendingState = await getRaceState();
+    assert.equal(stillPendingState.raceNumber, pendingState.raceNumber, `Expected active completion to remain pending, got: ${JSON.stringify(stillPendingState)}`);
+    assert.equal(stillPendingState.completion?.finalizedPlayerIds?.length ?? 0, 0, `Expected no finalized players during active retry, got: ${JSON.stringify(stillPendingState.completion)}`);
+
+    await setRaceState({
+      ...stillPendingState,
+      completion: {
+        ...stillPendingState.completion!,
+        activeExpiresAt: Date.now() - 1000,
+      },
+    });
+
+    const expiredRetry = await triggerRunRace();
+    assert.equal(expiredRetry.success, true, `Expected expired completion lease retry to succeed, logs: ${JSON.stringify(expiredRetry.logs)}`);
+    const afterExpiredRetryCurrency = await getCurrency(ctx.players[0].playerId);
+    assert.equal(afterExpiredRetryCurrency, beforeRetryCurrency + 100, 'Expected expired active lease to allow normal pending payout recovery exactly once');
+    const completedState = await getRaceState();
+    assert.equal(completedState.raceNumber, pendingState.raceNumber + 1, `Expected expired lease retry to advance race, got: ${JSON.stringify(completedState)}`);
+  });
+
+  it('uses custom horse-themed labels and entrants', async () => {
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        racerTypeLabel: 'horse',
+        racerTypePluralLabel: 'horses',
+        raceName: 'Derby',
+        entrants: ['Comet; 2', 'Storm; 4'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+
+    const result = await triggerCommand(ctx.players[0].playerId, 'racers');
+    assert.equal(result.success, true, `Expected /racers to succeed, logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('Derby')), `Expected custom race name, got: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('label=horses')), `Expected custom plural label, got: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('Comet:2')), `Expected custom entrant, got: ${JSON.stringify(result.logs)}`);
+
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+  });
+
+  it('falls back to legacy Horses config when entrants is absent', async () => {
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        racerTypeLabel: 'horse',
+        racerTypePluralLabel: 'horses',
+        raceName: 'Legacy Derby',
+        Horses: ['LegacyComet; 3', 'LegacyBolt; 5'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+
+    const result = await triggerCommand(ctx.players[0].playerId, 'racers');
+    assert.equal(result.success, true, `Expected /racers to succeed, logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('LegacyComet:3')), `Expected legacy Horses entrant, got: ${JSON.stringify(result.logs)}`);
+
+    await uninstallModule(client, moduleId, ctx.gameServer.id);
+  });
+
+  it('falls back to legacy Zombies config when entrants is absent', async () => {
+    await installModule(client, versionId, ctx.gameServer.id, {
+      userConfig: {
+        raceName: 'Legacy Zombie Race',
+        Zombies: ['LegacyBiter; 2', 'LegacyCrawler; 6'],
+        minBet: 10,
+        maxBet: 100,
+      },
+    });
+
+    const result = await triggerCommand(ctx.players[0].playerId, 'racers');
+    assert.equal(result.success, true, `Expected /racers to succeed, logs: ${JSON.stringify(result.logs)}`);
+    assert.ok(result.logs.some((msg) => msg.includes('LegacyBiter:2')), `Expected legacy Zombies entrant, got: ${JSON.stringify(result.logs)}`);
+  });
+});

--- a/test/helpers/mock-server.ts
+++ b/test/helpers/mock-server.ts
@@ -33,7 +33,14 @@ async function retry<T>(fn: () => Promise<T>, maxAttempts: number, delayMs: numb
   throw new Error('Retry exhausted');
 }
 
-export async function startMockServer(client: Client): Promise<MockServerContext> {
+export interface StartMockServerOptions {
+  totalPlayers?: number;
+}
+
+export async function startMockServer(
+  client: Client,
+  options: StartMockServerOptions = {},
+): Promise<MockServerContext> {
   const registrationToken = process.env['TAKARO_REGISTRATION_TOKEN'];
   const wsUrl = process.env['TAKARO_WS_URL'];
 
@@ -43,7 +50,7 @@ export async function startMockServer(client: Client): Promise<MockServerContext
   const identityToken = `test-${randomUUID()}`;
 
   const population = {
-    totalPlayers: 3,
+    totalPlayers: options.totalPlayers ?? 3,
   };
 
   const server = await getMockServer({


### PR DESCRIPTION
## Summary

Fixes #43 by importing the attached ZombieRacing module and turning it into a configurable racing module that can be themed around zombies, horses, or another entrant type. The module now has consistent commands, permissions, config, race state handling, and real Takaro API test coverage. It also includes recovery/idempotency safeguards around bets, race completion, payouts, and stats so players are not charged or credited incorrectly during retries or overlapping execution.

## Architecture

```text
Player/Bot command
  -> command handler (racers, racebet, myracebets, nextrace, startrace, etc.)
  -> utils.js shared helpers
      -> config parsing: entrants / legacy Zombies / legacy Horses
      -> race state variable: bets, last results, race number
      -> race lock + completion journal
      -> currency, stats, jackpot, final state updates
  -> Takaro command/cron execution events
```

## What Changed

- **Dynamic racing module**: Added `modules/zombie-racing` with configurable race labels, entrant labels, bet limits, and entrant lists while keeping zombie defaults and legacy `Zombies`/`Horses` config fallback.
- **Command surface**: Replaced inconsistent horse/zombie triggers with `racers`, `racebet`, `myracebets`, `racestats`, `raceleaderboard`, `nextrace`, `lastrace`, and `startrace` using `RACING_BET` / `RACING_ADMIN` permissions.
- **Race safety**: Added locking, lock renewal, completion leases, recoverable payout-pending state, idempotent stats updates, and duplicate-completion handling for overlapping commands/cronjobs.
- **Tests**: Added real Takaro API integration tests for permissions, betting, replacement refunds, config fallback, race execution, concurrency, recovery, and no-double-pay/no-double-stats behavior.
- **Test helper**: Added optional mock player count support so integration tests can start only the players they need.

## Reviewer Guide

- **Start here**: `modules/zombie-racing/src/functions/utils.js` for race state, locking, completion recovery, and shared helpers.
- **Command entry point**: `modules/zombie-racing/src/commands/racebet/index.js` for the highest-risk player-money path.
- **Tests**: `modules/zombie-racing/test/zombie-racing.test.ts` covers the expected API-level behavior and recovery cases.
- **Pay attention to**: race completion journal semantics: active completion returns busy, pending completion can recover, finalized completion is a no-op.

## Testing Plan

- [x] `npm run build`
- [x] `git diff --cached --check`
- [x] `node dist/scripts/module-to-json.js modules/zombie-racing >/tmp/zombie-racing-export.json`
- [x] Targeted real Takaro API suite: `16/16` passed
- [x] Paper + bot in-game verification with real `command-executed` events for `racers`, `racebet`, `myracebets`, `nextrace`, `startrace`, `lastrace`, `racestats`, and `raceleaderboard`

Full `npm test` was not rerun because this workspace has unrelated out-of-scope failures in other modules/untracked files.
