### PR TITLE
Add playtime buff rewards

### DIFF
--- a/.claude/plans/issue-42-playtime-buff-rewards.md
+++ b/.claude/plans/issue-42-playtime-buff-rewards.md
@@ -1,0 +1,26 @@
+# Issue #42: Playtime Buff Rewards
+
+## Summary
+Create a Takaro module based on playtime rewards that can grant configured buffs with the console command `buffplayer Playername BuffName`. Support scheduled playtime reward grants and a permission-gated admin command for manually granting or testing buffs.
+
+## Key Changes
+- Add `modules/playtime-buff-rewards`.
+- Add configurable reward pools:
+  - `buffRewards`: named buffs with optional weight/message/enabled fields.
+  - `commandRewards`: generic server command rewards for existing food/drink/ammo/med style rewards.
+  - `currencyRewards`: Takaro currency grants.
+- Add `buffCommandTemplate`, defaulting to `buffplayer {playerName} {buffName}`.
+- Add `/grantbuff <player> <buffName>` guarded by `PLAYTIME_BUFF_ADMIN`.
+- Use `takaro.gameserver.gameServerControllerExecuteCommand(gameServerId, { command })` for buff and command rewards.
+
+## Test Plan
+- Add real Takaro API integration tests for the cronjob and admin command.
+- Run `npm run build`.
+- Run module import conversion with `node dist/scripts/module-to-json.js modules/playtime-buff-rewards`.
+- Run targeted module tests when `TAKARO_HOST` and test services are available.
+- Push and verify in game with Paper + bot service before considering the module production-ready.
+
+## Assumptions
+- The customer command format `buffplayer Playername BuffName` is authoritative.
+- Player-name placeholders use the Takaro player/game-server display name when available.
+- Scheduled playtime rewards run hourly by default.

--- a/modules/playtime-buff-rewards/module.json
+++ b/modules/playtime-buff-rewards/module.json
@@ -1,0 +1,188 @@
+{
+  "name": "test-playtime-buff-rewards",
+  "description": "Hourly playtime rewards with configurable currency, command, and buff rewards.",
+  "version": "latest",
+  "supportedGames": [
+    "all"
+  ],
+  "config": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+      "buffCommandTemplate": {
+        "type": "string",
+        "default": "buffplayer {playerName} {buffName}",
+        "description": "Console command template used to grant a buff. Supports {playerName}, {playerId}, {gameId}, and {buffName}."
+      },
+      "announceRewards": {
+        "type": "boolean",
+        "default": true,
+        "description": "Broadcast a message when a playtime reward is granted."
+      },
+      "defaultRewardMessage": {
+        "type": "string",
+        "default": "{playerName} received a playtime reward: {rewardName}.",
+        "description": "Fallback message for rewards that do not define their own message."
+      },
+      "buffRewards": {
+        "type": "array",
+        "default": [
+          {
+            "buffName": "WellFed",
+            "weight": 1,
+            "enabled": true,
+            "message": "{playerName} received the {buffName} buff for playing."
+          }
+        ],
+        "description": "Buff rewards eligible for hourly playtime grants.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "buffName": {
+              "type": "string",
+              "description": "Buff name passed to the buff command.",
+              "pattern": "\\S"
+            },
+            "weight": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1,
+              "description": "Relative chance for this reward."
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "message": {
+              "type": "string",
+              "description": "Optional announcement template for this reward."
+            }
+          },
+          "required": [
+            "buffName"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "commandRewards": {
+        "type": "array",
+        "default": [],
+        "description": "Generic console-command rewards, useful for items such as food, drinks, ammo, or meds.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Human-readable reward name.",
+              "pattern": "\\S"
+            },
+            "command": {
+              "type": "string",
+              "description": "Console command template. Supports {playerName}, {playerId}, and {gameId}.",
+              "pattern": "\\S"
+            },
+            "weight": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "command"
+          ],
+          "additionalProperties": false
+        }
+      },
+      "currencyRewards": {
+        "type": "array",
+        "default": [],
+        "description": "Takaro currency rewards eligible for hourly playtime grants.",
+        "items": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "default": "Currency",
+              "description": "Human-readable reward name."
+            },
+            "amount": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Currency amount to grant."
+            },
+            "weight": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            },
+            "enabled": {
+              "type": "boolean",
+              "default": true
+            },
+            "message": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "amount"
+          ],
+          "additionalProperties": false
+        }
+      }
+    },
+    "required": [],
+    "additionalProperties": false
+  },
+  "uiSchema": {},
+  "permissions": [
+    {
+      "permission": "PLAYTIME_BUFF_ADMIN",
+      "friendlyName": "Manage Playtime Buff Rewards",
+      "description": "Allows manually granting buffs through the playtime buff rewards module.",
+      "canHaveCount": false
+    }
+  ],
+  "commands": {
+    "grant-buff": {
+      "trigger": "grantbuff",
+      "description": "Grant a configured buff to a player",
+      "helpText": "Grant a buff to a player. Usage: grantbuff <player> <buffName>",
+      "function": "src/commands/grant-buff/index.js",
+      "arguments": [
+        {
+          "name": "player",
+          "type": "player",
+          "helpText": "Player receiving the buff",
+          "position": 0
+        },
+        {
+          "name": "buffName",
+          "type": "string",
+          "helpText": "Buff name to grant",
+          "position": 1
+        }
+      ]
+    }
+  },
+  "hooks": {},
+  "cronJobs": {
+    "grant-playtime-rewards": {
+      "temporalValue": "0 * * * *",
+      "description": "Grant a random configured reward to each online player every hour.",
+      "function": "src/cronjobs/grant-playtime-rewards/index.js"
+    }
+  },
+  "functions": {
+    "playtime-buff-helpers": {
+      "function": "src/functions/playtime-buff-helpers.js"
+    }
+  }
+}

--- a/modules/playtime-buff-rewards/src/commands/grant-buff/index.js
+++ b/modules/playtime-buff-rewards/src/commands/grant-buff/index.js
@@ -1,0 +1,35 @@
+import { data, TakaroUserError, checkPermission } from '@takaro/helpers';
+import {
+  getCommandTargetPlayer,
+  grantBuffToPlayer,
+  normalizeBuffName,
+} from './playtime-buff-helpers.js';
+
+async function main() {
+  const { gameServerId, pog, arguments: args, module: mod } = data;
+
+  if (!checkPermission(pog, 'PLAYTIME_BUFF_ADMIN')) {
+    throw new TakaroUserError('You do not have permission to grant playtime buffs.');
+  }
+
+  const target = getCommandTargetPlayer(args.player);
+  if (!target) {
+    throw new TakaroUserError('Usage: grantbuff <player> <buffName> - please choose a valid player.');
+  }
+
+  const buffName = normalizeBuffName(args.buffName);
+  if (!buffName) {
+    throw new TakaroUserError('Usage: grantbuff <player> <buffName> - buffName is required.');
+  }
+
+  try {
+    const command = await grantBuffToPlayer(gameServerId, mod.userConfig || {}, target, buffName);
+    await pog.pm(`Granted buff ${buffName} to ${target.name}.`);
+    console.log(`playtime-buff-rewards: admin grant completed with command "${command}"`);
+  } catch (err) {
+    console.error(`playtime-buff-rewards: admin grant failed for target=${target.playerId} buff=${buffName}: ${err}`);
+    throw new TakaroUserError('The buff could not be granted. Check the game server command and try again.');
+  }
+}
+
+await main();

--- a/modules/playtime-buff-rewards/src/cronjobs/grant-playtime-rewards/index.js
+++ b/modules/playtime-buff-rewards/src/cronjobs/grant-playtime-rewards/index.js
@@ -1,0 +1,9 @@
+import { data } from '@takaro/helpers';
+import { grantPlaytimeRewards } from './playtime-buff-helpers.js';
+
+async function main() {
+  const { gameServerId, module: mod } = data;
+  await grantPlaytimeRewards(gameServerId, mod);
+}
+
+await main();

--- a/modules/playtime-buff-rewards/src/functions/playtime-buff-helpers.js
+++ b/modules/playtime-buff-rewards/src/functions/playtime-buff-helpers.js
@@ -1,0 +1,263 @@
+import { takaro } from '@takaro/helpers';
+
+const DEFAULT_BUFF_COMMAND_TEMPLATE = 'buffplayer {playerName} {buffName}';
+const DEFAULT_REWARD_MESSAGE = '{playerName} received a playtime reward: {rewardName}.';
+
+export function trimOrEmpty(value) {
+  if (value === undefined || value === null) return '';
+  return String(value).trim();
+}
+
+export function renderTemplate(template, placeholders) {
+  return trimOrEmpty(template).replace(/\{([a-zA-Z0-9_]+)\}/g, (_, key) => {
+    if (Object.prototype.hasOwnProperty.call(placeholders, key)) {
+      return String(placeholders[key]);
+    }
+    return `{${key}}`;
+  });
+}
+
+export function getCommandTargetPlayer(target) {
+  if (!target || typeof target !== 'object') return null;
+
+  const playerId = trimOrEmpty(target.playerId || target.id);
+  if (playerId === '') return null;
+
+  return {
+    playerId,
+    name: trimOrEmpty(target.name || target.playerName || target.player?.name) || 'Unknown Player',
+    gameId: trimOrEmpty(target.gameId),
+    online: target.online,
+  };
+}
+
+async function getPlayerName(playerId, fallback) {
+  try {
+    const res = await takaro.player.playerControllerGetOne(playerId);
+    return trimOrEmpty(res.data?.data?.name) || fallback;
+  } catch (err) {
+    console.error(`playtime-buff-rewards: failed to fetch player name for ${playerId}: ${err}`);
+    return fallback;
+  }
+}
+
+export function normalizeBuffName(value) {
+  const buffName = trimOrEmpty(value);
+  return buffName === '' ? null : buffName;
+}
+
+function normalizeWeight(value) {
+  const weight = Number(value ?? 1);
+  if (!Number.isFinite(weight) || weight < 1) return 1;
+  return Math.floor(weight);
+}
+
+function playerPlaceholders(target, extra = {}) {
+  return {
+    playerName: target.name,
+    playerId: target.playerId,
+    gameId: target.gameId || target.playerId,
+    ...extra,
+  };
+}
+
+export function buildBuffCommand(config, target, buffName) {
+  const template = trimOrEmpty(config?.buffCommandTemplate) || DEFAULT_BUFF_COMMAND_TEMPLATE;
+  return renderTemplate(template, playerPlaceholders(target, { buffName }));
+}
+
+function normalizeBuffRewards(config) {
+  const rewards = Array.isArray(config?.buffRewards) ? config.buffRewards : [];
+  return rewards
+    .filter((reward) => reward && reward.enabled !== false)
+    .map((reward) => {
+      const buffName = normalizeBuffName(reward.buffName);
+      if (!buffName) return null;
+      return {
+        type: 'buff',
+        name: buffName,
+        buffName,
+        weight: normalizeWeight(reward.weight),
+        message: trimOrEmpty(reward.message),
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeCommandRewards(config) {
+  const rewards = Array.isArray(config?.commandRewards) ? config.commandRewards : [];
+  return rewards
+    .filter((reward) => reward && reward.enabled !== false)
+    .map((reward) => {
+      const command = trimOrEmpty(reward.command);
+      const name = trimOrEmpty(reward.name);
+      if (command === '' || name === '') return null;
+      return {
+        type: 'command',
+        name,
+        command,
+        weight: normalizeWeight(reward.weight),
+        message: trimOrEmpty(reward.message),
+      };
+    })
+    .filter(Boolean);
+}
+
+function normalizeCurrencyRewards(config) {
+  const rewards = Array.isArray(config?.currencyRewards) ? config.currencyRewards : [];
+  return rewards
+    .filter((reward) => reward && reward.enabled !== false)
+    .map((reward) => {
+      const amount = Math.floor(Number(reward.amount));
+      if (!Number.isFinite(amount) || amount < 1) return null;
+      return {
+        type: 'currency',
+        name: trimOrEmpty(reward.name) || `${amount} currency`,
+        amount,
+        weight: normalizeWeight(reward.weight),
+        message: trimOrEmpty(reward.message),
+      };
+    })
+    .filter(Boolean);
+}
+
+export function getConfiguredRewards(config) {
+  return [
+    ...normalizeBuffRewards(config),
+    ...normalizeCommandRewards(config),
+    ...normalizeCurrencyRewards(config),
+  ];
+}
+
+export function pickWeightedReward(rewards) {
+  if (!Array.isArray(rewards) || rewards.length === 0) return null;
+  const totalWeight = rewards.reduce((sum, reward) => sum + normalizeWeight(reward.weight), 0);
+  let cursor = Math.random() * totalWeight;
+  for (const reward of rewards) {
+    cursor -= normalizeWeight(reward.weight);
+    if (cursor < 0) return reward;
+  }
+  return rewards[rewards.length - 1];
+}
+
+async function sendRewardMessage(gameServerId, config, target, reward, extra = {}) {
+  if (config?.announceRewards === false) return;
+
+  const template = trimOrEmpty(reward.message) || trimOrEmpty(config?.defaultRewardMessage) || DEFAULT_REWARD_MESSAGE;
+  const message = renderTemplate(template, playerPlaceholders(target, {
+    rewardName: reward.name,
+    buffName: reward.buffName || '',
+    amount: reward.amount || '',
+    ...extra,
+  }));
+
+  if (message === '') return;
+  await takaro.gameserver.gameServerControllerSendMessage(gameServerId, {
+    message,
+    opts: {},
+  });
+}
+
+export async function grantBuffToPlayer(gameServerId, config, target, buffName) {
+  const command = buildBuffCommand(config, target, buffName);
+  await takaro.gameserver.gameServerControllerExecuteCommand(gameServerId, { command });
+  console.log(`playtime-buff-rewards: executed buff command "${command}" for player ${target.name}`);
+  return command;
+}
+
+export async function grantRewardToPlayer(gameServerId, config, target, reward) {
+  if (reward.type === 'buff') {
+    const command = await grantBuffToPlayer(gameServerId, config, target, reward.buffName);
+    await sendRewardMessage(gameServerId, config, target, reward);
+    return { type: reward.type, name: reward.name, command };
+  }
+
+  if (reward.type === 'command') {
+    const command = renderTemplate(reward.command, playerPlaceholders(target, { rewardName: reward.name }));
+    await takaro.gameserver.gameServerControllerExecuteCommand(gameServerId, { command });
+    console.log(`playtime-buff-rewards: executed command reward "${command}" for player ${target.name}`);
+    await sendRewardMessage(gameServerId, config, target, reward);
+    return { type: reward.type, name: reward.name, command };
+  }
+
+  if (reward.type === 'currency') {
+    await takaro.playerOnGameserver.playerOnGameServerControllerAddCurrency(gameServerId, target.playerId, {
+      currency: reward.amount,
+    });
+    console.log(`playtime-buff-rewards: granted ${reward.amount} currency to ${target.name}`);
+    await sendRewardMessage(gameServerId, config, target, reward);
+    return { type: reward.type, name: reward.name, amount: reward.amount };
+  }
+
+  throw new Error(`Unsupported reward type: ${reward.type}`);
+}
+
+export async function findOnlinePlayers(gameServerId) {
+  const players = [];
+  const limit = 100;
+  let page = 0;
+  let iterations = 0;
+
+  while (true) {
+    iterations++;
+    if (iterations > 100) {
+      console.error('playtime-buff-rewards: exceeded online-player pagination cap');
+      break;
+    }
+
+    const res = await takaro.playerOnGameserver.playerOnGameServerControllerSearch({
+      filters: {
+        gameServerId: [gameServerId],
+        online: [true],
+      },
+      limit,
+      page,
+    });
+
+    const records = res.data.data;
+    const targets = await Promise.all(records.map(async (record) => {
+      const target = getCommandTargetPlayer(record);
+      if (!target) return null;
+      const fallbackName = target.gameId || target.playerId;
+      return {
+        ...target,
+        name: await getPlayerName(target.playerId, fallbackName),
+      };
+    }));
+    players.push(...targets.filter(Boolean));
+    if (records.length < limit) break;
+    page++;
+  }
+
+  return players;
+}
+
+export async function grantPlaytimeRewards(gameServerId, mod) {
+  const config = mod.userConfig || {};
+  const rewards = getConfiguredRewards(config);
+  if (rewards.length === 0) {
+    console.log('playtime-buff-rewards: no rewards configured');
+    return { playersChecked: 0, rewardsGranted: 0 };
+  }
+
+  const players = await findOnlinePlayers(gameServerId);
+  if (players.length === 0) {
+    console.log('playtime-buff-rewards: no online players found');
+    return { playersChecked: 0, rewardsGranted: 0 };
+  }
+
+  let rewardsGranted = 0;
+  for (const target of players) {
+    const reward = pickWeightedReward(rewards);
+    if (!reward) continue;
+    try {
+      await grantRewardToPlayer(gameServerId, config, target, reward);
+      rewardsGranted++;
+    } catch (err) {
+      console.error(`playtime-buff-rewards: failed to grant reward to ${target.name}: ${err}`);
+    }
+  }
+
+  console.log(`playtime-buff-rewards: granted ${rewardsGranted} reward(s) to ${players.length} online player(s)`);
+  return { playersChecked: players.length, rewardsGranted };
+}

--- a/modules/playtime-buff-rewards/test/playtime-buff-rewards.test.ts
+++ b/modules/playtime-buff-rewards/test/playtime-buff-rewards.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, before, after } from 'node:test';
+import assert from 'node:assert/strict';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { Client, EventSearchInputAllowedFiltersEventNameEnum } from '@takaro/apiclient';
+import { createClient } from '../../../test/helpers/client.js';
+import { startMockServer, stopMockServer, MockServerContext } from '../../../test/helpers/mock-server.js';
+import { waitForEvent } from '../../../test/helpers/events.js';
+import {
+  pushModule,
+  installModule,
+  uninstallModule,
+  deleteModule,
+  getCommandPrefix,
+  cleanupTestModules,
+  cleanupTestGameServers,
+  assignPermissions,
+  cleanupRole,
+} from '../../../test/helpers/modules.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const MODULE_DIR = path.resolve(__dirname, '..');
+
+type ExecutionMeta = { result?: { success?: boolean; logs?: Array<{ msg: string }> } };
+
+async function fetchPlayerName(client: Client, playerId: string): Promise<string> {
+  const result = await client.player.playerControllerGetOne(playerId);
+  return result.data.data.name;
+}
+
+describe('playtime-buff-rewards', () => {
+  let client: Client;
+  let ctx: MockServerContext | undefined;
+  let moduleId: string;
+  let versionId: string;
+  let cronjobId: string;
+  let prefix: string;
+  let adminRoleId: string | undefined;
+
+  before(async () => {
+    client = await createClient();
+    await cleanupTestModules(client);
+    await cleanupTestGameServers(client);
+    ctx = await startMockServer(client);
+
+    const mod = await pushModule(client, MODULE_DIR);
+    moduleId = mod.id;
+    versionId = mod.latestVersion.id;
+
+    const cronjob = mod.latestVersion.cronJobs[0];
+    if (!cronjob) throw new Error('Expected grant-playtime-rewards cronjob');
+    cronjobId = cronjob.id;
+
+    prefix = await getCommandPrefix(client, ctx.gameServer.id);
+
+    assert.ok(ctx.players[0], 'Expected at least one mock player');
+  });
+
+  after(async () => {
+    await cleanupRole(client, adminRoleId);
+    if (!ctx) return;
+    try {
+      await uninstallModule(client, moduleId, ctx.gameServer.id);
+    } catch (_err) {
+      // Ignore cleanup races.
+    }
+    try {
+      await deleteModule(client, moduleId);
+    } catch (err) {
+      console.error('Cleanup: failed to delete module:', err);
+    }
+    await stopMockServer(ctx.server, client, ctx.gameServer.id);
+  });
+
+  async function installWithBuffConfig(): Promise<void> {
+    await installModule(client, versionId, ctx!.gameServer.id, {
+      userConfig: {
+        buffCommandTemplate: 'buffplayer {playerName} {buffName}',
+        announceRewards: false,
+        buffRewards: [
+          {
+            buffName: 'CustomerBuff',
+            weight: 1,
+            enabled: true,
+          },
+        ],
+        commandRewards: [],
+        currencyRewards: [],
+      },
+    });
+  }
+
+  async function triggerCronjob(): Promise<{ success: boolean; logs: string[] }> {
+    const before = new Date();
+    await client.cronjob.cronJobControllerTrigger({
+      gameServerId: ctx!.gameServer.id,
+      cronjobId,
+      moduleId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CronjobExecuted,
+      gameserverId: ctx!.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    const meta = event.meta as ExecutionMeta;
+    const success = meta?.result?.success ?? false;
+    const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+    return { success, logs };
+  }
+
+  async function triggerCommand(message: string, playerId: string): Promise<{ success: boolean; logs: string[] }> {
+    const before = new Date();
+    await client.command.commandControllerTrigger(ctx!.gameServer.id, {
+      msg: `${prefix}${message}`,
+      playerId,
+    });
+
+    const event = await waitForEvent(client, {
+      eventName: EventSearchInputAllowedFiltersEventNameEnum.CommandExecuted,
+      gameserverId: ctx!.gameServer.id,
+      after: before,
+      timeout: 30000,
+    });
+
+    const meta = event.meta as ExecutionMeta;
+    const success = meta?.result?.success ?? false;
+    const logs = (meta?.result?.logs ?? []).map((l) => l.msg);
+    return { success, logs };
+  }
+
+  it('hourly playtime cron grants configured buff rewards through the game command', async () => {
+    await installWithBuffConfig();
+    try {
+      const { success, logs } = await triggerCronjob();
+
+      assert.equal(success, true, `Expected cronjob success, logs: ${JSON.stringify(logs)}`);
+      assert.ok(
+        logs.some((msg) => msg.includes('buffplayer') && msg.includes('CustomerBuff')),
+        `Expected buff command in logs, got: ${JSON.stringify(logs)}`,
+      );
+    } finally {
+      await uninstallModule(client, moduleId, ctx!.gameServer.id);
+    }
+  });
+
+  it('grantbuff admin command executes the configured buff command', async () => {
+    await installWithBuffConfig();
+    try {
+      adminRoleId = await assignPermissions(
+        client,
+        ctx!.players[0].playerId,
+        ctx!.gameServer.id,
+        ['PLAYTIME_BUFF_ADMIN'],
+      );
+      const targetName = await fetchPlayerName(client, ctx!.players[0].playerId);
+      const { success, logs } = await triggerCommand(`grantbuff ${targetName} ManualBuff`, ctx!.players[0].playerId);
+
+      assert.equal(success, true, `Expected grantbuff success, logs: ${JSON.stringify(logs)}`);
+      assert.ok(
+        logs.some((msg) => msg.includes('buffplayer') && msg.includes('ManualBuff')),
+        `Expected manual buff command in logs, got: ${JSON.stringify(logs)}`,
+      );
+      assert.ok(
+        logs.some((msg) => msg.includes(`buffplayer ${targetName} ManualBuff`)),
+        `Expected manual buff command to use target name ${targetName}, got: ${JSON.stringify(logs)}`,
+      );
+    } finally {
+      await cleanupRole(client, adminRoleId);
+      adminRoleId = undefined;
+      await uninstallModule(client, moduleId, ctx!.gameServer.id);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new Takaro module for issue #42 specifically for 7 Days to Die servers. It extends the PlaytimeReward idea with configurable buff grants, so server owners can keep hourly random playtime rewards for items/currency/commands and add 7D2D buffs using the customer-provided server-console command shape: `buffplayer Playername BuffName`.

The module also includes a permission-gated admin command so staff can manually grant or test a buff without waiting for the hourly reward cycle.

Closes #42.

## Architecture

```text
Takaro schedule / admin command
        |
        v
playtime-buff-helpers.js
        |
        +-- normalizes configured reward pools
        +-- renders player/buff command templates
        +-- executes game-server console commands
        +-- sends optional announcements / currency grants
        |
        v
Takaro game server command API -> 7 Days to Die console command
```

## What Changed

- **Playtime buff rewards module**: Adds `modules/playtime-buff-rewards` with an hourly cronjob and configurable reward pools for buffs, generic console commands, and Takaro currency.
- **7 Days to Die buff command support**: Adds `buffCommandTemplate`, defaulting to `buffplayer {playerName} {buffName}`, so 7D2D servers can call modded buffs directly.
- **Admin workflow**: Adds `/grantbuff <player> <buffName>` guarded by `PLAYTIME_BUFF_ADMIN` for manual grants and testing.
- **Tests**: Adds real Takaro API integration coverage for both scheduled buff grants and the admin command, including an assertion that the rendered command uses the target player's actual name.

## Reviewer Guide

- **Start here**: `modules/playtime-buff-rewards/module.json` for the public module surface and config schema.
- **Core logic**: `modules/playtime-buff-rewards/src/functions/playtime-buff-helpers.js` handles reward normalization, weighted selection, template rendering, and execution.
- **Pay attention to**: player-name resolution. Takaro player arguments can expose names through nested `target.player.name`, while online-player search records may require hydration through `playerControllerGetOne`.
- **Design decision**: This module is intended for 7 Days to Die. Paper verification used `say Buff {playerName} {buffName}` only to prove Takaro command execution on the available local Minecraft server. The module default remains the 7D2D-specific `buffplayer {playerName} {buffName}` requested by the customer.

## Testing Plan

### Happy Path
- [ ] Install `test-playtime-buff-rewards` on a 7 Days to Die server.
- [ ] Configure `buffRewards` with a real buff from the customer mod and leave `buffCommandTemplate` as `buffplayer {playerName} {buffName}`.
- [ ] Trigger the `grant-playtime-rewards` cronjob and verify the selected online player receives the buff in game.
- [ ] Grant a staff role `PLAYTIME_BUFF_ADMIN`, then run `/grantbuff <player> <buffName>` and verify the buff is applied.

### Edge Cases
- [ ] Run `/grantbuff` without permission and verify the player gets a permission error.
- [ ] Run `/grantbuff <player>` without a buff name and verify the usage error is clear.
- [ ] Disable a reward entry and verify it is not selected by the hourly reward cycle.
- [ ] Configure an empty reward pool and verify the cronjob succeeds without granting anything.

### Regression Checks
- [ ] Confirm existing module conversion still works with `npm run build` and `module-to-json`.
- [ ] Confirm generic command rewards still execute through `gameServerControllerExecuteCommand`.
- [ ] Confirm currency rewards still use Takaro currency grants instead of game console commands.

## Verification

- [x] `npm run build`
- [x] `npm run typecheck`
- [x] `node dist/scripts/module-to-json.js modules/playtime-buff-rewards /tmp/playtime-buff-rewards.json`
- [x] Targeted real Takaro API integration test: `2/2` passing for cron and `/grantbuff`
- [x] `scripts/module-push.sh modules/playtime-buff-rewards`
- [x] Paper + bot smoke for cron command execution using a Minecraft-safe `say Buff {playerName} {buffName}` template

## Notes

The local Paper server cannot validate the real 7 Days to Die `buffplayer` command. Final acceptance must happen on a 7D2D server with the customer's modded buff installed.