### PR TITLE
test(zombie-racing): disable scheduled crons during integration tests

### DIFF
--- a/modules/zombie-racing/test/zombie-racing.test.ts
+++ b/modules/zombie-racing/test/zombie-racing.test.ts
@@ -22,6 +22,31 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const MODULE_DIR = path.resolve(__dirname, '..');
 
+const DISABLED_CRONS = {
+  startRace: { enabled: false },
+  recoverRunningRace: { enabled: false },
+  announceRace: { enabled: false },
+};
+
+async function installRacingModule(
+  client: Client,
+  versionId: string,
+  gameServerId: string,
+  config?: { userConfig?: Record<string, unknown>; systemConfig?: Record<string, unknown> },
+): Promise<void> {
+  const systemConfig = {
+    ...(config?.systemConfig ?? {}),
+    cronJobs: {
+      ...DISABLED_CRONS,
+      ...((config?.systemConfig as { cronJobs?: Record<string, unknown> } | undefined)?.cronJobs ?? {}),
+    },
+  };
+  await installModule(client, versionId, gameServerId, {
+    userConfig: config?.userConfig,
+    systemConfig,
+  });
+}
+
 type ExecutionResult = {
   success: boolean;
   logs: string[];
@@ -105,7 +130,7 @@ describe('zombie-racing: commands and race flow', () => {
     moduleId = mod.id;
     versionId = mod.latestVersion.id;
 
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         minBet: 25,
         maxBet: 250,
@@ -597,7 +622,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('broadcasts configurable race commentary during a manual race', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         entrants: ['Solo; 2', 'Chaser; 2', 'Rival; 2'],
         minBet: 10,
@@ -633,7 +658,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('does not double-pay when duplicate finish executions run', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         entrants: ['Solo; 2'],
         minBet: 10,
@@ -697,7 +722,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('recovers stranded payout-pending race completion without double-paying', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         entrants: ['Solo; 2'],
         minBet: 10,
@@ -765,7 +790,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('does not update stats twice when recovering after stats were written before finalization', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         entrants: ['Solo; 2', 'Other; 2'],
         minBet: 10,
@@ -856,7 +881,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('does not resume an active long-running completion after the outer lock expires', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         entrants: ['Solo; 2'],
         minBet: 10,
@@ -937,7 +962,7 @@ describe('zombie-racing: commands and race flow', () => {
 
   it('uses custom horse-themed labels and entrants', async () => {
     await uninstallModule(client, moduleId, ctx.gameServer.id);
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         racerTypeLabel: 'horse',
         racerTypePluralLabel: 'horses',
@@ -958,7 +983,7 @@ describe('zombie-racing: commands and race flow', () => {
   });
 
   it('falls back to legacy Horses config when entrants is absent', async () => {
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         racerTypeLabel: 'horse',
         racerTypePluralLabel: 'horses',
@@ -977,7 +1002,7 @@ describe('zombie-racing: commands and race flow', () => {
   });
 
   it('falls back to legacy Zombies config when entrants is absent', async () => {
-    await installModule(client, versionId, ctx.gameServer.id, {
+    await installRacingModule(client, versionId, ctx.gameServer.id, {
       userConfig: {
         raceName: 'Legacy Zombie Race',
         Zombies: ['LegacyBiter; 2', 'LegacyCrawler; 6'],


### PR DESCRIPTION
## Summary
The scheduled \`startRace\` cron fires at minute 0 every 2 hours. When a CI test run crossed a 2-hour boundary (e.g. 20:00 UTC), the cron started a race mid-test, leaving the race state in \`running\` and breaking every subsequent test that expected a fresh betting state. Off the boundary, only the commentary test (test 10) failed for a related state-pollution reason.

Tests trigger cronjobs directly via the API, so the scheduled timer is not needed. This adds an \`installRacingModule\` helper that disables \`startRace\`, \`recoverRunningRace\`, and \`announceRace\` on every install via systemConfig, and routes all 9 install sites through it.

## Background
PR #49 was merged with this same test suite failing on CI. The failure was a real test-isolation bug, not flakiness — it just happens to be sensitive to wall-clock time, which is why it appeared as 1 failure (commentary test) most runs and as 10 failures when CI happened to land on a 2-hour boundary.

## Test plan
- [ ] Reviewer: confirm CI passes here (no scheduled-cron interference).
- [ ] Reviewer: spot-check that the helper correctly merges cron overrides if a test ever needs to enable one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)